### PR TITLE
Import v0.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,127 @@
+#[[ Need 3.19+ for HANDLE_VERSION_RANGE support in the FindPhpConfig module.
+    This should be checked in the FindPhpConfig.cmake file somehow, but I do not
+    know to do this yet, so we do it here instead.
+ ]]
+cmake_minimum_required(VERSION 3.19)
+
+project(datadog-php-workspace
+  LANGUAGES C CXX
+)
+
+# Add cmake/Modules to CMAKE_MODULE_PATH so find_package(PhpConfig) will work
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
+
+if(UNIX) # This is probably a bit too broad
+  include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/configurations.cmake)
+
+  #[[ For some reason, I often write "RelWithDebugInfo" instead of the correct
+      "RelWithDebInfo". This code will error on an unknown build type.
+      These checks depend on cmake/configurations.cmake, so that's why it's done
+      only in this branch.
+  ]]
+  if(CMAKE_BUILD_TYPE)
+    get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    get_property(allowedBuildTypes CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS)
+    if(NOT isMultiConfig AND NOT CMAKE_BUILD_TYPE IN_LIST allowedBuildTypes)
+      message(FATAL_ERROR "Invalid build type: ${CMAKE_BUILD_TYPE}; allowed build types: ${allowedBuildTypes}")
+    endif()
+  endif()
+endif()
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_POSITION_INDEPENDENT_CODE on)
+
+option(DATADOG_PHP_TESTING OFF)
+if(DATADOG_PHP_TESTING)
+  enable_testing()
+
+  find_package(Catch2 REQUIRED)
+  include(Catch)
+
+  if (NOT TARGET Catch2::Catch2WithMain AND TARGET Catch2::Catch2)
+    #[[ The build of catch2 we are using wasn't configured with
+        `CATCH_BUILD_STATIC_LIBRARY`; let's polyfill it.
+    ]]
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/catch2withmain.cc
+      "#define CATCH_CONFIG_MAIN\n"
+      "#include <catch2/catch.hpp>\n"
+    )
+
+    add_library(Catch2WithMain ${CMAKE_CURRENT_BINARY_DIR}/catch2withmain.cc)
+    target_compile_features(Catch2WithMain INTERFACE cxx_std_11)
+    target_link_libraries(Catch2WithMain PUBLIC Catch2::Catch2)
+    add_library(Catch2::Catch2WithMain ALIAS Catch2WithMain)
+  endif ()
+
+  if (NOT TARGET Catch2::Catch2WithMain)
+    message(FATAL_ERROR "Catch2WithMain not found and polyfill failed.")
+  endif ()
+endif ()
+
+find_package(Threads REQUIRED)
+find_package(PhpConfig 7.1...8.1 REQUIRED)
+find_package(PkgConfig REQUIRED)
+
+#[[ Prefer libuv-static, but note that it needs to be built with Position
+    Independent Code (PIC).
+ ]]
+pkg_check_modules(UV IMPORTED_TARGET libuv-static)
+if (NOT UV_FOUND)
+  pkg_check_modules(UV REQUIRED IMPORTED_TARGET libuv)
+endif()
+
+add_subdirectory(components)
+
+find_package(DDProf REQUIRED)
+
+add_subdirectory(profiling)
+
+add_library(datadog-profiling MODULE
+  datadog-profiling.c
+  profiling/datadog-profiling.c
+  profiling/datadog-profiling.h
+  profiling/plugins/log_plugin/log_plugin.c
+  profiling/plugins/recorder_plugin/recorder_plugin.c
+  profiling/plugins/stack_collector_plugin/stack_collector_plugin.c
+)
+
+target_link_libraries(datadog-profiling
+  PRIVATE
+    datadog-php-arena
+    datadog-php-channel
+    datadog-php-log
+    datadog_php_sapi
+    datadog-php-stack-collector
+    datadog-php-stack-sample
+    datadog_php_string_view
+    datadog-php-time
+    DDProf::FFI
+    PkgConfig::UV
+    PhpConfig::PhpConfig
+    Threads::Threads
+)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  set_target_properties(datadog-profiling PROPERTIES
+    LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/datadog-profiling.sym
+  )
+
+  include(CheckCCompilerFlag)
+  check_c_compiler_flag(-static-libgcc HAS_STATIC_LIBGCC)
+
+  if(HAS_STATIC_LIBGCC)
+    target_link_options(datadog-profiling PRIVATE -static-libgcc)
+  endif()
+
+  target_link_options(datadog-profiling PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/datadog-profiling.sym)
+endif()
+
+set_target_properties(datadog-profiling PROPERTIES
+  PREFIX "" # PHP modules are not prefixed with lib*
+  C_VISIBILITY_PRESET hidden
+)
+
+target_include_directories(datadog-profiling
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/components>
+)

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,0 +1,4 @@
+Component,Origin,License,Copyright
+libuv,https://github.com/libuv/libuv,MIT,Copyright (c) 2015-present libuv project contributors
+protobuf-c,https://github.com/protobuf-c/protobuf-c,BSD-2-Clause,Copyright (c) 2008-2016 Dave Benson and the protobuf-c authors
+protobuf,https://github.com/protocolbuffers/protobuf,BSD-3-Clause,Copyright 2008 Google Inc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# Datadog Continuous Profiler for PHP
+
+The Datadog PHP profiler is a Zend Extension for PHP 7.1+. Debug and ZTS builds
+are not currently supported.
+
+Supported platforms (all x86-64):
+ - CentOS 7+ GNU/Linux. This works for most glibc based Linux versions that have
+   glibc 2.17 or newer.
+ - Alpine 3.13+ with musl.
+
+Additionally, it has been developed and tested on MacOS Big Sur (11.6).
+
+The plan for this code is to be eventually merged into
+[Datadog/dd-trace-php](https://github.com/DataDog/dd-trace-php).
+
+## Installing
+
+Users should install via the Tracer's installations script.
+TODO: add more details about this.
+
+The agent needs to be at least v7.20 or v6.20.
+
+## Configuring
+
+The profiler uses these environment variables. If the tracer is already set up,
+then you may not need to adjust any of them:
+
+ - `DD_PROFILING_ENABLED`: defaults to `on` except for the CLI SAPI, which
+   defaults to `off`.
+ - `DD_PROFILING_LOG_LEVEL`: defaults to `off`. Acceptable values are `off`,
+   `error`, `warn`, `info`, and `debug`. Log message are printed to stderr, not
+   to the PHP `error_log`.
+ - `DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED`: defaults to `off`, as it is
+   experimental. It has low overhead, but is biased towards functions that do
+   I/O (not desriable, but perhaps still useful).
+ - `DD_ENV`: defaults to the empty string.
+ - `DD_SERVICE`: defaults to the empty string. If not set, this will become
+   `unnamed-php-service` in the Datadog UI.
+ - `DD_AGENT_HOST`: defaults to `localhost`.
+ - `DD_TRACE_AGENT_PORT`: defaults to `8126`.
+ - `DD_TRACE_AGENT_URL`: defaults to the empty string. If set, this will
+   override `DD_AGENT_HOST` and `DD_TRACE_AGENT_POR`.
+
+### Building From Source
+
+For people who really want to build from source, like other Datadog Engineers,
+you will need:
+
+ - CMake 3.19 or newer to generate the build
+ - Make or Ninja
+ - C11 compiler
+ - pkg-config
+ - PHP 7.1+
+ - libuv (todo: min version?) and its headers
+ - libddprof v0.2 for your platform. This is a Rust library, so I recommend
+   using the pre-built artifacts available at
+   [Datadog/libddprof](https://github.com/DataDog/libddprof/releases) so you
+   don't need a Rust toolchain.
+
+Here's an example of how to build it, based on my own development machine:
+
+```bash
+# Set up environment so cmake can find libuv and libddprof
+LIBUV_ROOT="$(readlink -e $(brew --prefix libuv))"
+export DDProf_ROOT="/opt/libddprof"
+
+export PKG_CONFIG_PATH="$(find ${LIBUV_ROOT?} -name pkgconfig -type d):$PKG_CONFIG_PATH"
+
+# Build profiler in Release configuration
+cmake -S . -B cmake-build-release -DCMAKE_BUILD_TYPE=Release -G Ninja
+cmake --build cmake-build-release
+
+# Run diagnostics
+DD_PROFILING_ENABLED=yes php \
+    -dzend_extension=cmake-build-release/datadog-profiling.so \
+    --ri datadog-profiling
+
+# Optional: Install the profiler
+export PHP_INI_DIR="$(php-config --ini-dir)"
+export PHP_EXTENSION_DIR="$(php-config --extension-dir)"
+cp -v cmake-build-release/datadog-profiling.so "${PHP_EXTENSION_DIR?}/"
+echo 'zend_extension = datadog-profiling.so' > "${PHP_INI_DIR?}/datadog-profiling.ini"
+```

--- a/cmake/Modules/FindPhpConfig.cmake
+++ b/cmake/Modules/FindPhpConfig.cmake
@@ -1,0 +1,125 @@
+include(FindPackageHandleStandardArgs)
+
+#[[ As of CMake 3.12, the environment variable <Package>_ROOT holds prefixes
+    set by the user that should be searched in for <Package>.
+ ]]
+if(DEFINED ENV{PhpConfig_ROOT})
+  set(PhpConfig_ROOT "$ENV{PhpConfig_ROOT}")
+elseif(NOT PhpConfig_ROOT)
+  set(PhpConfig_ROOT "" CACHE STRING "Directory containing bin/php-config")
+endif()
+
+find_program(PhpConfig_EXECUTABLE
+  NAMES php-config
+  HINTS ${PhpConfig_ROOT} # not quoted! Need it to expand to a list.
+)
+
+#[[ The following variables are common for find modules, and are documented:
+    https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html
+    - <PackageName>_INCLUDE_DIRS (used)
+    - <PackageName>_LIBRARIES (used)
+    - <PackageName>_DEFINITIONS (not used; should probably set ZTS this way)
+    - <PackageName>_EXECUTABLE (used)
+    - <PackageName>_LIBRARY_DIRS (used)
+    - <PackageName>_ROOT_DIR (used, this is php-config --prefix)
+    - <PackageName>_VERSION (used; full version string may include rc1, etc)
+    - <PackageName>_VERSION_MAJOR (used)
+    - <PackageName>_VERSION_MINOR (used)
+    - <PackageName>_VERSION_PATCH (used)
+ ]]
+
+if(PhpConfig_EXECUTABLE)
+  execute_process(COMMAND ${PhpConfig_EXECUTABLE} --prefix
+    RESULT_VARIABLE PhpConfig_PREFIX_RESULT
+    OUTPUT_VARIABLE PhpConfig_ROOT_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+  )
+
+  execute_process(COMMAND ${PhpConfig_EXECUTABLE} --includes
+    RESULT_VARIABLE PhpConfig_INCLUDES_RESULT
+    OUTPUT_VARIABLE PhpConfig_INCLUDE_DIRS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+  )
+
+  execute_process(COMMAND ${PhpConfig_EXECUTABLE} --ldflags
+    RESULT_VARIABLE PhpConfig_LDFLAGS_RESULT
+    OUTPUT_VARIABLE PhpConfig_LIBRARY_DIRS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+  )
+
+  execute_process(COMMAND ${PhpConfig_EXECUTABLE} --libs
+    RESULT_VARIABLE PhpConfig_LIBS_RESULT
+    OUTPUT_VARIABLE PhpConfig_LIBRARIES
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+  )
+
+  execute_process(COMMAND ${PhpConfig_EXECUTABLE} --version
+    RESULT_VARIABLE PhpConfig_VERSION_RESULT
+    OUTPUT_VARIABLE PhpConfig_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+  )
+
+  execute_process(COMMAND ${PhpConfig_EXECUTABLE} --vernum
+    RESULT_VARIABLE PhpConfig_VERNUM_RESULT
+    OUTPUT_VARIABLE PhpConfig_VERNUM
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+  )
+
+  string(REGEX REPLACE "^([0-9]+)[0-9][0-9][0-9][0-9]$" "\\1" PhpConfig_VERSION_MAJOR "${PhpConfig_VERNUM}")
+  string(REGEX REPLACE "^0([0-9])$" "\\1" PhpConfig_VERSION_MAJOR "${PhpConfig_VERSION_MAJOR}")
+
+  string(REGEX REPLACE "[0-9]+([0-9][0-9])[0-9][0-9]$" "\\1" PhpConfig_VERSION_MINOR "${PhpConfig_VERNUM}")
+  string(REGEX REPLACE "^0([0-9])$" "\\1" PhpConfig_VERSION_MINOR "${PhpConfig_VERSION_MINOR}")
+
+  string(REGEX REPLACE "[0-9]+([0-9][0-9])$" "\\1" PhpConfig_VERSION_PATCH "${PhpConfig_VERNUM}")
+  string(REGEX REPLACE "^0([0-9])$" "\\1" PhpConfig_VERSION_PATCH "${PhpConfig_VERSION_PATCH}")
+endif()
+
+find_package_handle_standard_args(PhpConfig
+  REQUIRED_VARS PhpConfig_EXECUTABLE PhpConfig_ROOT_DIR
+  VERSION_VAR PhpConfig_VERSION
+  HANDLE_VERSION_RANGE
+)
+
+if(PhpConfig_FOUND)
+  separate_arguments(PhpConfig_INCLUDE_DIRS)
+  separate_arguments(PhpConfig_LIBRARY_DIRS)
+
+  string(REPLACE "-I" "" PhpConfig_INCLUDE_DIRS "${PhpConfig_INCLUDE_DIRS}")
+  string(REPLACE "-L" "" PhpConfig_LIBRARY_DIRS "${PhpConfig_LIBRARY_DIRS}")
+
+  mark_as_advanced(PhpConfig_EXECUTABLE)
+
+  #[[ Produce a target for users to link with, so they don't have to add all
+      these settings, which may change over time. Example:
+      target_link_libraries(mylib PRIVATE PhpConfig::PhpConfig)
+   ]]
+  add_library(PhpConfig INTERFACE)
+  target_include_directories(PhpConfig INTERFACE ${PhpConfig_INCLUDE_DIRS})
+  target_link_directories(PhpConfig INTERFACE ${PhpConfig_LIBRARY_DIRS})
+  target_compile_features(PhpConfig INTERFACE c_std_99)
+
+  #[[ Do not link these automatically, as they are probably unused and can
+      cause extra runtime linking dependencies.
+  ]]
+  # target_link_libraries(PhpConfig INTERFACE ${PhpConfig_LIBRARIES})
+
+  #[[ On Linux, undefined symbols do not cause the compile time linker to error,
+      but the Darwin linker will. The PHP ecosystem does not link against a
+      common library like libzend.so and the symbols are provided by the PHP
+      SAPI instead. So, when compiling a module for PHP allow for undefined
+      symbols (sadly, as this means you don't get an error until runtime linking
+      instead).
+   ]]
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    target_link_options(PhpConfig INTERFACE -undefined dynamic_lookup)
+  endif()
+
+  add_library(PhpConfig::PhpConfig ALIAS PhpConfig)
+endif()

--- a/cmake/configurations.cmake
+++ b/cmake/configurations.cmake
@@ -1,0 +1,62 @@
+# This pattern is in the book Professional CMake; I referenced 8th edition.
+
+set(CMAKE_C_FLAGS_DEBUG "-O0 -g3" CACHE STRING "C flags" FORCE)
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g3" CACHE STRING "C++ flags" FORCE)
+
+#[[ RelWithDebInfo by default will do -O2 -g -DNDEBUG, which is reasonable.
+    Release by default will do -O3 -DNDEBUG, which is also reasonable.
+    However, we can get a better debugging experience for RelWithDebInfo
+    with -Og -g -DNDEBUG. We also want release builds to have symbols.
+    So, we tinker with the flags.
+]]
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-Og -g3 -DNDEBUG" CACHE STRING "C flags" FORCE)
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-Og -g3 -DNDEBUG" CACHE STRING "C++ flags" FORCE)
+
+set(CMAKE_C_FLAGS_RELEASE "-O3 -g1 -DNDEBUG" CACHE STRING "C flags" FORCE)
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -g1 -DNDEBUG" CACHE STRING "C++ flags" FORCE)
+
+get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
+if(isMultiConfig)
+  if(NOT "RelWithAsan" IN_LIST CMAKE_CONFIGURATION_TYPES)
+    list(APPEND CMAKE_CONFIGURATION_TYPES RelWithAsan)
+  endif()
+else()
+  get_property(allowedBuildTypes CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS)
+  if (NOT "Debug" IN_LIST allowedBuildTypes)
+    list(APPEND allowedBuildTypes Debug)
+  endif()
+  if (NOT "RelWithDebInfo" IN_LIST allowedBuildTypes)
+    list(APPEND allowedBuildTypes RelWithDebInfo)
+  endif()
+  if (NOT "RelWithAsan" IN_LIST allowedBuildTypes)
+    list(APPEND allowedBuildTypes RelWithAsan)
+  endif()
+  if (NOT "Release" IN_LIST allowedBuildTypes)
+    list(APPEND allowedBuildTypes Release)
+  endif()
+  if (NOT "MinSizeRel" IN_LIST allowedBuildTypes)
+    list(APPEND allowedBuildTypes MinSizeRel)
+  endif()
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${allowedBuildTypes}")
+endif()
+
+set(CMAKE_C_FLAGS_RELWITHASAN
+  "-O1 -g -DNDEBUG -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
+  "Flags used by the C compiler for theRelWithAsan build type." FORCE)
+
+set(CMAKE_CXX_FLAGS_RELWITHASAN
+  "-O1 -g -DNDEBUG -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
+  "Flags used by the C++ compiler for the RelWithAsan build type." FORCE)
+
+set(CMAKE_EXE_LINKER_FLAGS_RELWITHASAN
+  "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=address" CACHE STRING
+  "Flags to be used to create executables for the RelWithAsan build type." FORCE)
+
+set(CMAKE_SHARED_LINKER_FLAGS_RELWITHASAN
+  "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=address" CACHE STRING
+  "Flags used to create shared libraries for the RelWithAsan build type." FORCE)
+
+set(CMAKE_MODULE_LINKER_FLAGS_RELWITHASAN
+  "${CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=address" CACHE STRING
+  "Flags used to create modules for the RelWithAsan build type." FORCE)

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_subdirectory(string_view)
+
+add_subdirectory(arena)
+add_subdirectory(channel)
+add_subdirectory(log)
+add_subdirectory(queue)
+add_subdirectory(sapi)
+add_subdirectory(stack-sample)
+add_subdirectory(time)

--- a/components/arena/CMakeLists.txt
+++ b/components/arena/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(datadog-php-arena OBJECT arena.c)
+
+target_include_directories(datadog-php-arena
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+target_compile_features(datadog-php-arena
+  INTERFACE c_std_99
+  PRIVATE c_std_11
+)
+
+if (DATADOG_PHP_TESTING)
+  add_subdirectory(tests)
+endif ()

--- a/components/arena/arena.c
+++ b/components/arena/arena.c
@@ -1,0 +1,102 @@
+#include "arena.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct datadog_php_arena_s {
+  uint32_t offset, capacity;
+  uint8_t *start;
+};
+
+void datadog_php_arena_delete(datadog_php_arena *arena) { (void)arena; }
+void datadog_php_arena_reset(datadog_php_arena *arena) { arena->offset = 0; }
+
+static uint32_t align_diff(uintptr_t ptr, uint32_t align) {
+  /* The `align` must be a power of two, which means it has a single bit set:
+   * 0b0100
+   * By subtracting one, the bits below the only set bit will all be 1, while
+   * that bit and above will all be 0:
+   * 0b0011
+   */
+  uintptr_t lower_bits_mask = align - 1;
+
+  /* Here's how (~ptr) + 1 evaluates for a few numbers:
+   * Each group is distinct:
+   *      0     1     2     3     4     5     6     7     8
+   * into binary:
+   *   0000  0001  0010  0011  0100  0101  0110  0111  1000
+   * ~ ====  ====  ====  ====  ====  ====  ====  ====  ====
+   *   1111  1110  1101  1100  1011  1010  1001  1000  0111
+   * + 0001  0001  0001  0001  0001  0001  0001  0001  0001
+   *   ====  ====  ====  ====  ====  ====  ====  ====  ====
+   *  10000  1111  1110  1101  1100  1011  1010  1001  1000
+   */
+  uintptr_t inverted = (~ptr) + 1; // parens are redundant
+
+  /* Okay, let's use an alignment of 8, which is a mask of 0111 (or 7)
+   * on the numbers from above:
+   *  10000  1111  1110  1101  1100  1011  1010  1001  1000
+   * & 0111  0111  0111  0111  0111  0111  0111  0111  0111
+   *   ====  ====  ====  ====  ====  ====  ====  ====  ====
+   *   0000  0111  0110  0101  0100  0011  0010  0001  0000
+   * Converted to decimal:
+   *      0     7     6     5     4     3     2     1     0
+   * which check out; add those to our original numbers and they all become
+   * a multiple of 8 (yes, 0 is a multiple of 8):
+   *      0     1     2     3     4     5     6     7     8
+   * +    0     7     6     5     4     3     2     1     0
+   *      =     =     =     =     =     =     =     =     =
+   *      0     8     8     8     8     8     8     8     8
+   */
+  uintptr_t diff = inverted & lower_bits_mask;
+  return diff;
+}
+
+uint32_t datadog_php_arena_align_diff(uintptr_t ptr, uint32_t align) {
+  uint32_t diff = align_diff(ptr, align);
+  return diff;
+}
+
+datadog_php_arena *datadog_php_arena_new(uint32_t len,
+                                         uint8_t buffer[static len]) {
+  if (!len) {
+    return NULL;
+  }
+
+  uint32_t diff = align_diff((uintptr_t)buffer, _Alignof(datadog_php_arena));
+  uint8_t *obj = buffer + diff;
+
+  // ensure the alignment + size fits
+  if ((diff + sizeof(datadog_php_arena)) > len) {
+    return NULL;
+  }
+
+  datadog_php_arena *allocator = (datadog_php_arena *)obj;
+  allocator->offset = 0;
+  allocator->capacity = len - sizeof(datadog_php_arena) - diff;
+  allocator->start = obj + sizeof(datadog_php_arena);
+
+  return allocator;
+}
+
+uint8_t *datadog_php_arena_alloc(datadog_php_arena *arena, uint32_t size,
+                                 uint32_t align) {
+  // minimum allocation size is 1 byte
+  size = size ? size : 1;
+
+  // align the offset
+  uint8_t *begin = arena->start + arena->offset;
+  uint32_t diff = align_diff((uintptr_t)begin, align);
+  ptrdiff_t offset = arena->offset + diff;
+
+  // ensure it doesn't go out of bounds
+  if (offset + size > arena->capacity) {
+    return NULL;
+  }
+
+  unsigned char *obj = arena->start + offset;
+
+  // bump the offset
+  arena->offset = offset + size;
+  return obj;
+}

--- a/components/arena/arena.h
+++ b/components/arena/arena.h
@@ -1,0 +1,84 @@
+#ifndef DATADOG_PHP_ARENA_H
+#define DATADOG_PHP_ARENA_H
+
+#include <stdint.h>
+
+#if __cplusplus
+#define C_STATIC(...)
+#else
+#define C_STATIC(...) static __VA_ARGS__
+#endif
+
+#if __GNUC__
+#if __GNUC__ >= 11
+#define HAVE_ATTRIBUTE_MALLOC_EXTENDED 1
+#endif
+#endif
+
+#if HAVE_ATTRIBUTE_MALLOC_EXTENDED
+/* Note that GCC 11 doesn't yet do a good job with this attribute, but
+ * experimenting with it to report bugs so it hopefully gets better.
+ */
+#define DATADOG_PHP__ATTR_MALLOC_EXTENDED(...)                                 \
+  __attribute__((malloc(__VA_ARGS__)))
+#else
+#define DATADOG_PHP__ATTR_MALLOC_EXTENDED(...)
+#endif
+
+/**
+ * This arena is used to do bump pointer style allocations inside of a
+ * previously allocated block, such as stack memory, static storage, or heap
+ * memory.
+ *
+ * Individual allocations made by the arena are not tracked and are not freed.
+ * The use-case is allocating a bunch of data which has the same lifetime, and
+ * then everything can be freed at once by freeing the arena. This means that
+ * care must be taken to either not store types which have custom destructors,
+ * or that they should be tracked and dtor'd outside of the arena.
+ */
+typedef struct datadog_php_arena_s datadog_php_arena;
+
+/**
+ * This is a no-op at present, but it theoretically helps the GCC analyzer to
+ * understand the lifetime of the arena.
+ * Note that it cannot be inline, as deallocator functions cannot be inline.
+ */
+void datadog_php_arena_delete(datadog_php_arena *arena);
+
+/**
+ * Creates a new arena from the provided `buffer` + `len`. This function may
+ * return NULL, such as if `len` is not large enough to hold the arena object.
+ *
+ * # Safety
+ * The `buffer` object must have at least `len` contiguous bytes and must not
+ * be null.
+ */
+DATADOG_PHP__ATTR_MALLOC_EXTENDED(datadog_php_arena_delete)
+datadog_php_arena *datadog_php_arena_new(uint32_t len,
+                                         uint8_t buffer[C_STATIC(len)]);
+
+/**
+ * Resets the arena contents, but the arena object itself stays valid. All other
+ * objects that have been allocated by the arena are now invalid.
+ */
+__attribute__((nonnull(1))) void
+datadog_php_arena_reset(datadog_php_arena *arena);
+
+/**
+ * Returns the number of bytes to add to `ptr` to align it to `align`. Only
+ * pass powers of 2 for `align`!
+ */
+uint32_t datadog_php_arena_align_diff(uintptr_t ptr, uint32_t align);
+
+/**
+ * Allocates at least `size` bytes from the `arena`, aligned to `align`. May
+ * return NULL, such as if `align` is not a power of two or if there is not
+ * enough remaining space in the `arena` storage.
+ */
+__attribute__((nonnull(1))) uint8_t *
+datadog_php_arena_alloc(datadog_php_arena *arena, uint32_t size,
+                        uint32_t align);
+
+#undef C_STATIC
+
+#endif // DATADOG_PHP_ARENA_H

--- a/components/arena/tests/CMakeLists.txt
+++ b/components/arena/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(test-datadog-php-arena arena.cc)
+target_link_libraries(test-datadog-php-arena
+  PRIVATE Catch2::Catch2WithMain datadog-php-arena
+)
+
+catch_discover_tests(test-datadog-php-arena)

--- a/components/arena/tests/arena.cc
+++ b/components/arena/tests/arena.cc
@@ -1,0 +1,105 @@
+extern "C" {
+#include <components/arena/arena.h>
+}
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("new and delete", "[arena]") {
+  alignas(32) static uint8_t buffer[1024];
+
+  datadog_php_arena *arena = datadog_php_arena_new(sizeof buffer, buffer);
+  REQUIRE(arena);
+  datadog_php_arena_delete(arena);
+}
+
+TEST_CASE("generic alignment", "[arena]") {
+  uintptr_t addr = 8u;
+
+  CHECK(datadog_php_arena_align_diff(addr + 0, 4) == 0u);
+  CHECK(datadog_php_arena_align_diff(addr + 1, 4) == 3u);
+  CHECK(datadog_php_arena_align_diff(addr + 2, 4) == 2u);
+  CHECK(datadog_php_arena_align_diff(addr + 3, 4) == 1u);
+  CHECK(datadog_php_arena_align_diff(addr + 4, 4) == 0u);
+  CHECK(datadog_php_arena_align_diff(addr + 5, 4) == 3u);
+}
+
+TEST_CASE("allocator self-alignment", "[arena]") {
+  alignas(16) uint8_t bytes[24];
+
+  /* Since buffer is aligned to an even byte boundary, by passing in a pointer
+   * + 1 (and taking 1 off the size to match), we can test that the arena
+   * object itself gets correctly aligned in the buffer, since there is no
+   * guarantee that the buffer has suitable alignment.
+   */
+  datadog_php_arena *arena = datadog_php_arena_new(sizeof bytes - 1, &bytes[1]);
+  REQUIRE(arena);
+
+  // uses some implementation-specific knowledge
+  REQUIRE(((uint8_t *)arena) == bytes + alignof(uintptr_t));
+
+  datadog_php_arena_delete(arena);
+}
+
+TEST_CASE("capacity and reset", "[arena]") {
+  // This requires implementation-specific knowledge of datadog_php_arena
+  alignas(8) uint8_t bytes[20];
+
+  datadog_php_arena *arena = datadog_php_arena_new(sizeof bytes, bytes);
+  REQUIRE(arena);
+
+  uint8_t *i = datadog_php_arena_alloc(arena, 4, 1);
+  REQUIRE(i);
+
+  // This allocation should fail; no more room.
+  uint8_t *j = datadog_php_arena_alloc(arena, 1, 1);
+  REQUIRE(!j);
+
+  datadog_php_arena_reset(arena);
+
+  // Since we have reset the arena, this should allocate the same address
+  uint8_t *k = datadog_php_arena_alloc(arena, 4, 1);
+  REQUIRE(i == k);
+
+  datadog_php_arena_delete(arena);
+}
+
+TEST_CASE("allocation alignment", "[arena]") {
+  // This requires implementation-specific knowledge of datadog_php_arena
+  alignas(16) uint8_t bytes[24];
+
+  datadog_php_arena *arena = datadog_php_arena_new(sizeof bytes, bytes);
+  REQUIRE(arena);
+
+  /* Intentionally use a size and align combo that will set up the next alloc
+   * to start misaligned.
+   */
+  uint8_t *i = datadog_php_arena_alloc(arena, 1, 1);
+  REQUIRE(i);
+
+  uint8_t *j = datadog_php_arena_alloc(arena, 4, 4);
+  REQUIRE(j);
+  REQUIRE(i + 4 == j);
+
+  // This allocation should fail; no more room.
+  uint8_t *k = datadog_php_arena_alloc(arena, 1, 1);
+  REQUIRE(!k);
+
+  datadog_php_arena_delete(arena);
+}
+
+TEST_CASE("allocation alignment capacity", "[arena]") {
+  // This requires implementation-specific knowledge of datadog_php_arena
+  alignas(16) uint8_t bytes[24];
+
+  datadog_php_arena *arena = datadog_php_arena_new(sizeof bytes, bytes);
+  REQUIRE(arena);
+
+  uint8_t *i = datadog_php_arena_alloc(arena, 1, 1);
+  REQUIRE(i);
+
+  // This allocation would fit except for its alignment
+  uint8_t *j = datadog_php_arena_alloc(arena, 7, 2);
+  REQUIRE(!j);
+
+  datadog_php_arena_delete(arena);
+}

--- a/components/channel/CMakeLists.txt
+++ b/components/channel/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_library(datadog-php-channel channel.c)
+target_include_directories(datadog-php-channel
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+target_compile_features(datadog-php-channel
+  INTERFACE c_std_99
+  PRIVATE c_std_11
+)
+
+# libuv's pc file doesn't put -pthread into its link line, but it depends on it
+# for all our current platforms.
+find_package(Threads REQUIRED)
+target_link_libraries(datadog-php-channel
+  PRIVATE datadog-php-queue PkgConfig::UV Threads::Threads
+)
+
+if (DATADOG_PHP_TESTING)
+  add_subdirectory(tests)
+endif ()

--- a/components/channel/channel.c
+++ b/components/channel/channel.c
@@ -1,0 +1,186 @@
+#include "channel.h"
+
+#include <components/queue/queue.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <uv.h>
+
+struct datadog_php_channel_impl_s {
+  datadog_php_queue queue;
+
+  // enforce single consumer (refcount should be 0 or 1)
+  uint32_t receiver_count;
+
+  /* Multiple producers are fine. When there aren't any items in the queue, the
+   * consumer will use this info to determine whether to try waiting for more
+   * data or to return empty handed. If there is a known producer, it will wait;
+   * otherwise it will return without waiting.
+   */
+  uint32_t sender_count;
+
+  uv_mutex_t mutex;
+  uv_cond_t condvar;
+  void *buffer[];
+};
+
+/**
+ * Destroys the channel. _NOT_ thread safe.
+ */
+static void channel_dtor(datadog_php_channel_impl *channel) {
+  uv_mutex_destroy(&channel->mutex);
+  uv_cond_destroy(&channel->condvar);
+  free(channel);
+}
+
+static bool receiver_recv(struct datadog_php_receiver_s *receiver, void **data,
+                          uint64_t timeout_nanos) {
+  if (!receiver || !receiver->channel) {
+    return false;
+  }
+
+  datadog_php_channel_impl *channel = receiver->channel;
+  uv_mutex_lock(&channel->mutex);
+  datadog_php_queue *queue = &channel->queue;
+  bool succeeded = datadog_php_queue_try_pop(queue, data);
+
+  // If there wasn't an item but there are known producers, wait and try again
+  if (!succeeded && channel->sender_count && timeout_nanos) {
+    uint64_t now = uv_hrtime();
+    uint64_t timeout_target = now + timeout_nanos;
+    do {
+      /* Handle being signalled, waking up spuriously, and timing out the
+       * same. Note that the mutex will be released while waiting, and
+       * the mutex will be re-acquired when resuming.
+       */
+      (void)uv_cond_timedwait(&channel->condvar, &channel->mutex,
+                              timeout_target - now);
+      succeeded = datadog_php_queue_try_pop(queue, data);
+      if (succeeded) {
+        break;
+      }
+
+      now = uv_hrtime();
+    } while (channel->sender_count && now < timeout_target);
+  }
+
+  uv_mutex_unlock(&channel->mutex);
+  return succeeded;
+}
+
+static void receiver_dtor(struct datadog_php_receiver_s *receiver) {
+  if (receiver && receiver->channel) {
+    datadog_php_channel_impl *channel = receiver->channel;
+    receiver->channel = NULL;
+    uv_mutex_lock(&channel->mutex);
+    // todo: underflow checks
+    bool dtor = !(--channel->receiver_count | channel->sender_count);
+    uv_mutex_unlock(&channel->mutex);
+
+    // Cannot dtor the mutex while it is held.
+    if (dtor) {
+      channel_dtor(channel);
+    }
+  }
+}
+
+static bool sender_send(struct datadog_php_sender_s *sender, void *data) {
+  if (!sender || !sender->channel) {
+    return false;
+  }
+
+  datadog_php_channel_impl *channel = sender->channel;
+  uv_mutex_lock(&channel->mutex);
+  datadog_php_queue *queue = &channel->queue;
+  bool sent = datadog_php_queue_try_push(queue, data);
+  if (sent) {
+    uv_cond_signal(&channel->condvar);
+  }
+  uv_mutex_unlock(&channel->mutex);
+  return sent;
+}
+
+static void sender_dtor(struct datadog_php_sender_s *sender) {
+  if (sender && sender->channel) {
+    datadog_php_channel_impl *channel = sender->channel;
+    sender->channel = NULL;
+    uv_mutex_lock(&channel->mutex);
+    // todo: underflow check
+    bool dtor = !(channel->receiver_count | --channel->sender_count);
+    uv_mutex_unlock(&channel->mutex);
+
+    // Cannot dtor the mutex while it is held.
+    if (dtor) {
+      channel_dtor(channel);
+    }
+  }
+}
+
+static bool sender_clone(datadog_php_sender *self, datadog_php_sender *clone) {
+  if (!self || !clone || !self->channel) {
+    return false;
+  }
+
+  datadog_php_channel_impl *channel = self->channel;
+  uv_mutex_lock(&channel->mutex);
+  // todo: overflow checks
+  ++channel->sender_count;
+  uv_mutex_unlock(&channel->mutex);
+
+  *clone = *self;
+
+  return true;
+}
+
+// not thread safe
+static void receiver_ctor(datadog_php_receiver *receiver,
+                          datadog_php_channel_impl *channel) {
+  receiver->recv = receiver_recv;
+  receiver->dtor = receiver_dtor;
+  receiver->channel = channel;
+}
+
+// not thread safe
+static void sender_ctor(datadog_php_sender *sender,
+                        datadog_php_channel_impl *channel) {
+  sender->send = sender_send;
+  sender->clone = sender_clone;
+  sender->dtor = sender_dtor;
+  sender->channel = channel;
+}
+
+bool datadog_php_channel_ctor(datadog_php_channel *channel, uint16_t capacity) {
+  size_t bytes =
+      offsetof(datadog_php_channel_impl, buffer) + sizeof(void *) * capacity;
+  datadog_php_channel_impl *impl = malloc(bytes);
+  if (!impl) {
+    return false;
+  }
+
+  receiver_ctor(&channel->receiver, impl);
+  sender_ctor(&channel->sender, impl);
+
+  if (!datadog_php_queue_ctor(&impl->queue, capacity, impl->buffer)) {
+    goto cleanup_impl;
+  }
+
+  impl->receiver_count = 1;
+  impl->sender_count = 1;
+
+  if (uv_mutex_init(&impl->mutex) != 0) {
+    goto cleanup_impl;
+  }
+
+  if (uv_cond_init(&impl->condvar) != 0) {
+    goto cleanup_mutex;
+  }
+
+  return true;
+
+cleanup_mutex:
+  uv_mutex_destroy(&impl->mutex);
+
+cleanup_impl:
+  free(impl);
+  return false;
+}

--- a/components/channel/channel.h
+++ b/components/channel/channel.h
@@ -1,0 +1,78 @@
+#ifndef DATADOG_PHP_CHANNEL_H
+#define DATADOG_PHP_CHANNEL_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct datadog_php_receiver_s datadog_php_receiver;
+typedef struct datadog_php_sender_s datadog_php_sender;
+typedef struct datadog_php_channel_s datadog_php_channel;
+typedef struct datadog_php_channel_impl_s datadog_php_channel_impl;
+
+struct datadog_php_receiver_s {
+  /**
+   * Receives an item, waiting for a send to the channel if necessary.
+   * However, it may return empty-handed and return false, such as if there are
+   * no senders left, or the timeout is reached, or if it is interrupted.
+   */
+  bool (*recv)(datadog_php_receiver *self, void **data, uint64_t timeout_nanos);
+
+  /**
+   * Destructs the receiver.
+   */
+  void (*dtor)(datadog_php_receiver *self);
+
+  // private:
+  datadog_php_channel_impl *channel;
+};
+
+struct datadog_php_sender_s {
+  /**
+   * Sends data through the channel. May fail, in which case the caller is
+   * responsible for dtor'ing the data if applicable. Does not wait for the
+   * data to be received, only enqueued.
+   */
+  bool (*send)(datadog_php_sender *self, void *data);
+
+  /**
+   * Clones the sender. Can fail if there are too many senders already, in
+   * which false is returned and the caller should not dtor the clone.
+   */
+  bool (*clone)(datadog_php_sender *self, datadog_php_sender *clone);
+
+  /**
+   * Destructs the sender. Must be done on each successful clone as well.
+   */
+  void (*dtor)(datadog_php_sender *self);
+
+  // private:
+  datadog_php_channel_impl *channel;
+};
+
+/**
+ * datadog_php_channel is a bounded, multiple-producer, single-consumer channel
+ * suitable for inter-thread communication.
+ *
+ * The user is responsible for any additional cleanup of contents; it does not
+ * assume pointers are malloc'd.
+ *
+ * The channel is not destructed directly. It must outlive any senders and
+ * receivers, and the last sender/receiver must dtor the channel when the
+ * last sender/receiver is destructed.
+ *
+ * In the end, I hope this is migrated to Rust, and then we can stop writing
+ * our own concurrency primitives and have better lifetime management.
+ */
+struct datadog_php_channel_s {
+  // public:
+  datadog_php_receiver receiver;
+  datadog_php_sender sender;
+};
+
+/**
+ * Creates a channel with the sender and receiver members fully initialized.
+ * The sender and receiver must be .dtor'd.
+ */
+bool datadog_php_channel_ctor(datadog_php_channel *channel, uint16_t capacity);
+
+#endif // DATADOG_PHP_CHANNEL_H

--- a/components/channel/tests/CMakeLists.txt
+++ b/components/channel/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(test-datadog-php-channel channel.cc)
+
+target_link_libraries(test-datadog-php-channel
+  PRIVATE Catch2::Catch2WithMain datadog-php-channel PkgConfig::UV
+)
+
+# Channels have deadlock opportunities, so set a timeout
+catch_discover_tests(test-datadog-php-channel PROPERTIES TIMEOUT 20)

--- a/components/channel/tests/channel.cc
+++ b/components/channel/tests/channel.cc
@@ -1,0 +1,230 @@
+extern "C" {
+#include <components/channel/channel.h>
+}
+
+#include <uv.h>
+
+#include <catch2/catch.hpp>
+
+static void print_assert(const char *expr, const char *file, int line) {
+  fprintf(stderr, "assertion \"%s\" failed: in file \"%s\", on line %d\n", expr,
+          file, line);
+}
+
+// avoid UINT64_MAX due to likely math overflow logic errors
+static const uint64_t TIMEOUT = UINT64_C(10000000000);
+
+// Catch2's macros are not thread-safe, so return a bool for status
+struct args {
+  bool succeeded;
+  datadog_php_sender *sender;
+  datadog_php_receiver *receiver;
+};
+
+static void basic_receiver_job(args *args) {
+  datadog_php_receiver *receiver = args->receiver;
+  int *item;
+  // clang-format off
+#define ASSERT(EXPR) (void)((EXPR) || (print_assert(#EXPR, __FILE__, __LINE__), args->succeeded = false))
+  // clang-format on
+  ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+  ASSERT(*item == 1);
+  ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+  ASSERT(*item == 2);
+  ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+  ASSERT(*item == 3);
+  ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+  ASSERT(*item == 4);
+#undef ASSERT
+}
+
+TEST_CASE("basic channel operations", "[channel]") {
+  uv_thread_t receiver_thread;
+
+  constexpr const uint16_t n = 4;
+  int values[n] = {1, 2, 3, 4};
+
+  datadog_php_channel channel;
+  REQUIRE(datadog_php_channel_ctor(&channel, n));
+
+  datadog_php_receiver *receiver = &channel.receiver;
+  datadog_php_sender *sender = &channel.sender;
+
+  args args = {
+      true,
+      nullptr,
+      receiver,
+  };
+  REQUIRE(uv_thread_create(&receiver_thread,
+                           reinterpret_cast<uv_thread_cb>(basic_receiver_job),
+                           &args) == 0);
+
+  REQUIRE(sender->send(sender, &values[0]));
+  REQUIRE(sender->send(sender, &values[1]));
+  REQUIRE(sender->send(sender, &values[2]));
+  REQUIRE(sender->send(sender, &values[3]));
+
+  REQUIRE(uv_thread_join(&receiver_thread) == 0);
+
+  REQUIRE(args.succeeded);
+
+  receiver->dtor(receiver);
+  sender->dtor(sender);
+}
+
+static void stream_channel_ops(args *args) {
+  datadog_php_receiver *receiver = args->receiver;
+  datadog_php_sender *sender = args->sender;
+  int *item;
+
+  // clang-format off
+#define ASSERT(EXPR) (void)((EXPR) || (print_assert(#EXPR, __FILE__, __LINE__), args->succeeded = false))
+  // clang-format on
+
+  ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+  ASSERT(*item == 1);
+  ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+  ASSERT(*item == 2);
+
+  // notify the other channel we've recv'd the first two items
+  ASSERT(sender->send(sender, nullptr));
+
+  ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+  ASSERT(*item == 2);
+  ASSERT(receiver->recv(receiver, (void **)&item, TIMEOUT));
+  ASSERT(*item == 1);
+#undef ASSERT
+}
+
+TEST_CASE("stream channel operations", "[channel]") {
+  uv_thread_t receiver_thread;
+
+  constexpr const uint16_t n = 2;
+  int values[n] = {1, 2};
+
+  datadog_php_channel A, B;
+  REQUIRE(datadog_php_channel_ctor(&A, n));
+  REQUIRE(datadog_php_channel_ctor(&B, n));
+
+  args ops = {
+      true,
+      &B.sender,
+      &A.receiver,
+  };
+  REQUIRE(uv_thread_create(&receiver_thread,
+                           reinterpret_cast<uv_thread_cb>(stream_channel_ops),
+                           &ops) == 0);
+  REQUIRE(A.sender.send(&A.sender, &values[0]));
+  REQUIRE(A.sender.send(&A.sender, &values[1]));
+
+  /* Since the buffer is only 2 in size, we need to make sure the other values
+   * have been recv'd before sending new ones, or new ones will fail to send.
+   * This is the purpose of the second channel.
+   */
+  void *item;
+  REQUIRE(B.receiver.recv(&B.receiver, &item, TIMEOUT));
+
+  // The previous sends have been recv'd; we are clear to send new values.
+  A.sender.send(&A.sender, &values[1]);
+  A.sender.send(&A.sender, &values[0]);
+
+  REQUIRE(uv_thread_join(&receiver_thread) == 0);
+
+  REQUIRE(ops.succeeded);
+
+  A.receiver.dtor(&A.receiver);
+  A.sender.dtor(&A.sender);
+  B.receiver.dtor(&B.receiver);
+  B.sender.dtor(&B.sender);
+}
+
+TEST_CASE("channel empty recv does not wait if no producers", "[channel]") {
+  constexpr const uint16_t n = 1;
+  datadog_php_channel channel;
+  REQUIRE(datadog_php_channel_ctor(&channel, n));
+
+  // close the sender so when the receiver recvs there aren't any senders
+  channel.sender.dtor(&channel.sender);
+
+  void *item;
+  REQUIRE(!channel.receiver.recv(&channel.receiver, &item, TIMEOUT));
+  // todo: if this doesn't pass, it will likely run until the caller kills it
+
+  channel.receiver.dtor(&channel.receiver);
+}
+
+#define ASSERT(EXPR)                                                           \
+  (void)((EXPR) ||                                                             \
+         (print_assert(#EXPR, __FILE__, __LINE__), args->succeeded = false))
+static void send4(args *args) {
+  datadog_php_sender *sender = args->sender;
+  datadog_php_receiver *receiver = args->receiver;
+  void *done = nullptr;
+
+  int items[4] = {2, 4, 6, 8};
+
+  ASSERT(sender->send(sender, items + 0));
+  ASSERT(sender->send(sender, items + 1));
+  ASSERT(sender->send(sender, items + 2));
+  ASSERT(sender->send(sender, items + 3));
+
+  // We passed stack variables, so block until they've been received.
+  ASSERT(receiver->recv(receiver, (void **)&done, TIMEOUT));
+}
+#undef ASSERT
+
+TEST_CASE("channel multiple producers easy", "[channel]") {
+  // ensure there is enough capacity without contention
+  constexpr const int capacity = 8;
+  datadog_php_channel channel;
+  REQUIRE(datadog_php_channel_ctor(&channel, capacity));
+
+  datadog_php_channel sync[2];
+  REQUIRE(datadog_php_channel_ctor(sync + 0, 1));
+  REQUIRE(datadog_php_channel_ctor(sync + 1, 1));
+
+  datadog_php_sender additional_sender;
+  REQUIRE(channel.sender.clone(&channel.sender, &additional_sender));
+
+  args args[2] = {
+      {true, &channel.sender, &sync[0].receiver},
+      {true, &additional_sender, &sync[1].receiver},
+  };
+  uv_thread_t threads[2];
+  REQUIRE(uv_thread_create(&threads[0], reinterpret_cast<uv_thread_cb>(send4),
+                           &args[0]) == 0);
+  REQUIRE(uv_thread_create(&threads[1], reinterpret_cast<uv_thread_cb>(send4),
+                           &args[1]) == 0);
+
+  datadog_php_receiver *receiver = &channel.receiver;
+
+  int sum = 0;
+  for (int i = 0; i < capacity; ++i) {
+    int *item = nullptr;
+    CHECK(receiver->recv(receiver, (void **)&item, TIMEOUT));
+    sum += *item;
+  }
+
+  for (auto chan : sync) {
+    // Sent value is unused; just using it to sync.
+    CHECK(chan.sender.send(&chan.sender, (void *)&chan));
+  }
+
+  for (auto thread : threads) {
+    CHECK(uv_thread_join(&thread) == 0);
+  }
+
+  for (auto chan : sync) {
+    chan.sender.dtor(&chan.sender);
+    chan.receiver.dtor(&chan.receiver);
+  }
+
+  CHECK(sum == 40);
+
+  additional_sender.dtor(&additional_sender);
+  channel.sender.dtor(&channel.sender);
+  channel.receiver.dtor(&channel.receiver);
+
+  CHECK(args[0].succeeded);
+  CHECK(args[1].succeeded);
+}

--- a/components/log/CMakeLists.txt
+++ b/components/log/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_library(datadog-php-log OBJECT log.c)
+
+target_include_directories(datadog-php-log
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+target_compile_features(datadog-php-log
+  INTERFACE c_std_99
+  PRIVATE c_std_11
+)
+
+target_link_libraries(datadog-php-log PUBLIC datadog_php_string_view)
+
+if (DATADOG_PHP_TESTING)
+  add_subdirectory(tests)
+endif ()

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -1,0 +1,174 @@
+#include "log.h"
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+
+// The names are long, so let's add a convenience helpers
+typedef datadog_php_logger logger_t;
+typedef datadog_php_log_level log_level_t;
+typedef datadog_php_string_view string_view_t;
+
+/**
+ * Ensures the logger looks like it should be logging anything at all.
+ *
+ * # Safety
+ * Mutex must exist and be locked prior to calling this function if used in a
+ * multi-threaded context.
+ * `logger` must not be null.
+ */
+__attribute__((nonnull)) static bool logger_valid(datadog_php_logger *logger) {
+  return logger->descriptor >= 0 && logger->log_level >= DATADOG_PHP_LOG_OFF &&
+      logger->log_level <= DATADOG_PHP_LOG_DEBUG;
+}
+
+__attribute__((nonnull)) bool datadog_php_logger_ctor(logger_t *logger,
+                                                      int descriptor,
+                                                      log_level_t log_level,
+                                                      pthread_mutex_t *mutex) {
+  *logger = (logger_t){
+      .descriptor = descriptor < 0 ? -1 : descriptor, // normalize invalid
+      .log_level = log_level,
+      .mutex = mutex,
+  };
+  return logger_valid(logger);
+}
+
+void datadog_php_logger_dtor(logger_t *logger) {
+  logger->descriptor = -1;
+  logger->log_level = DATADOG_PHP_LOG_UNKNOWN;
+  logger->mutex = NULL;
+}
+
+static int64_t durable_write(const logger_t *logger, string_view_t message) {
+  /* We attempt to handle some of the error conditions possible:
+   *  1. Partial writes
+   *  2. EAGAIN and EWOULDBLOCK
+   *  3. EINTR
+   * We limit the number of times we'll retry an operation for the above.
+   * For other errors we stop attempting to log and move on.
+   * todo: should we set the fd to -1 for some errors like EIO/EPIPE?
+   */
+  size_t written = 0;
+  unsigned tries = 0, max_tries = 3; // arbitrarily chosen
+  while (written < message.len && tries++ < max_tries) {
+    ssize_t n =
+        write(logger->descriptor, message.ptr + written, message.len - written);
+    if (n < 0) {
+      /* POSIX.1-2001 allows either error to be returned for this case, and does
+       * not require these constants to have the same value, so a portable
+       * application should check for both possibilities.
+       */
+      if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+        continue;
+      } else {
+        break;
+      }
+    }
+    written += n;
+  }
+  return written == message.len ? (int64_t)written : -1;
+}
+
+static int64_t log_writev(logger_t *logger, log_level_t level,
+                          size_t n_messages,
+                          string_view_t messages[static n_messages]) {
+  if (logger->log_level < level) {
+    return 0;
+  }
+
+  int64_t written = 0;
+  for (size_t i = 0; i != n_messages; ++i) {
+    int64_t result = durable_write(logger, messages[i]);
+    if (result < 0)
+      break;
+    written += result;
+  }
+
+  // try to append a newline
+  ssize_t result = write(logger->descriptor, "\n", 1);
+  if (result > 0)
+    written += result;
+  return written;
+}
+
+void datadog_php_log(logger_t *logger, log_level_t level,
+                     string_view_t message) {
+  (void)datadog_php_logv(logger, level, 1, &message);
+}
+
+int64_t datadog_php_logv(datadog_php_logger *logger,
+                         datadog_php_log_level level, size_t n_messages,
+                         datadog_php_string_view messages[static n_messages]) {
+  if (logger->mutex && pthread_mutex_lock(logger->mutex) == 0) {
+    int64_t result = logger_valid(logger)
+        ? log_writev(logger, level, n_messages, messages)
+        : -1;
+    (void)pthread_mutex_unlock(logger->mutex);
+    return result;
+  }
+  return -1;
+}
+
+static char datadog_tolower_ascii(char c) {
+  return (char)(c >= 'A' && c <= 'Z' ? (c - ('A' - 'a')) : c);
+}
+
+static void datadog_copy_tolower(char *restrict dst, const char *restrict src,
+                                 size_t len) {
+  for (size_t i = 0; i != len; ++i) {
+    *(dst++) = datadog_tolower_ascii(src[i]);
+  }
+}
+
+log_level_t datadog_php_log_level_detect(string_view_t val) {
+  // Treat nullptr and a string of length 0 the same: default to off.
+  if (!val.ptr || val.len == 0)
+    return DATADOG_PHP_LOG_OFF;
+
+  // If the level string's length is greater than 5, it's definitely unknown.
+  if (val.len > 5)
+    return DATADOG_PHP_LOG_UNKNOWN;
+
+  // 8 chars is more than enough to hold the remaining strings.
+  _Alignas(8) char buffer[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+  // lowercase to make this a case-insensitive operation
+  datadog_copy_tolower(buffer, val.ptr, val.len);
+  string_view_t level_string = {.len = val.len, .ptr = buffer};
+
+  struct {
+    string_view_t str;
+    log_level_t level;
+  } options[] = {
+      {{3, "off"}, DATADOG_PHP_LOG_OFF},
+      {{5, "error"}, DATADOG_PHP_LOG_ERROR},
+      {{4, "warn"}, DATADOG_PHP_LOG_WARN},
+      {{4, "info"}, DATADOG_PHP_LOG_INFO},
+      {{5, "debug"}, DATADOG_PHP_LOG_DEBUG},
+
+      /* This case goes last. We've already ruled out this case above; this is
+       * for unifying known and unknown code paths below.
+       */
+      {{0, ""}, DATADOG_PHP_LOG_UNKNOWN},
+  };
+
+  // the last option is only used for its enum, so take off 1
+  unsigned i, n_options = (sizeof options / sizeof *options) - 1;
+  for (i = 0; i != n_options; ++i) {
+    if (datadog_php_string_view_equal(options[i].str, level_string)) {
+      break;
+    }
+  }
+  return options[i].level;
+}
+
+/**
+ * Sets the current log level of the application.
+ */
+void datadog_php_log_level_set(logger_t *logger, log_level_t level) {
+  if (logger->mutex && pthread_mutex_lock(logger->mutex) == 0) {
+    logger->log_level = level;
+    pthread_mutex_unlock(logger->mutex);
+  }
+}

--- a/components/log/log.h
+++ b/components/log/log.h
@@ -1,0 +1,107 @@
+#ifndef DATADOG_PHP_PROFILER_LOG_H
+#define DATADOG_PHP_PROFILER_LOG_H
+
+#include <components/string_view/string_view.h>
+#include <pthread.h>
+#include <stdint.h>
+
+#if __cplusplus
+#define C_STATIC(...)
+#else
+#define C_STATIC(...) static __VA_ARGS__
+#endif
+
+typedef enum {
+  DATADOG_PHP_LOG_UNKNOWN = -1,
+  DATADOG_PHP_LOG_OFF = 0,
+  DATADOG_PHP_LOG_ERROR,
+  DATADOG_PHP_LOG_WARN,
+  DATADOG_PHP_LOG_INFO,
+  DATADOG_PHP_LOG_DEBUG,
+} datadog_php_log_level;
+
+// This is for the compiler to use; please do not use it directly!
+typedef struct datadog_php_logger_s {
+  int descriptor; // borrowed, not owned
+  int log_level;
+  pthread_mutex_t *mutex; // borrowed, not owned
+} datadog_php_logger;
+
+#define DATADOG_PHP_LOGGER_INIT                                                \
+  { -1, DATADOG_PHP_LOG_UNKNOWN, NULL }
+
+/**
+ * Creates a logger instance in `logger`. The result may be valid or invalid;
+ * check the return value: `true` for valid.
+ *
+ * For now, only file descriptors are expected to work, but other types are
+ * expected to work in the future.
+ */
+__attribute__((nonnull)) bool
+datadog_php_logger_ctor(datadog_php_logger *logger, int descriptor,
+                        datadog_php_log_level log_level,
+                        pthread_mutex_t *mutex);
+
+/**
+ * Sets the .descriptor to -1, .log_level to `DATADOG_PROFILER_LOG_UNKNOWN`,
+ * and the .mutex to NULL.
+ *
+ * This is not threadsafe! It also doesn't close the descriptor nor destroy the
+ * mutex, as they are borrowed, not owned. Only do this when the program is
+ * back in single-threaded mode, or you risk a race condition.
+ *
+ * @param logger
+ */
+void datadog_php_logger_dtor(datadog_php_logger *logger);
+
+/**
+ * If the `logger` is set to at least `level`, then the message will be logged.
+ * Otherwise it will be ignored.
+ * @param logger
+ * @param level
+ * @param message
+ */
+void datadog_php_log(datadog_php_logger *logger, datadog_php_log_level level,
+                     datadog_php_string_view message);
+
+/**
+ * If the `logger` is set to at least `level`, then the messages will be logged.
+ * Otherwise they will be ignored.
+ * @param logger
+ * @param level
+ * @param n_messages
+ * @param messages
+ * @return Bytes written
+ */
+int64_t
+datadog_php_logv(datadog_php_logger *logger, datadog_php_log_level level,
+                 size_t n_messages,
+                 datadog_php_string_view messages[C_STATIC(n_messages)]);
+
+/**
+ * Sets the current `.log_level` of the logger.
+ * Inputs of UNKNOWN are ignored, and the logger retain its current values.
+ *
+ * Generally the `.log_level` should be set at construction and remain
+ * unchanged. However, there may be reasons to change it. Here are a few:
+ *   - A logger may need to be be constructed so it can be shared by multiple
+ *     objects prior to knowing the runtime setting of the log level.
+ *   - At a certain point during datadog_php_log_plugin_shutdown, logging may
+ * need to be set to off but since the logger is still being borrowed by other
+ * objects it cannot be destructed.
+ */
+void datadog_php_log_level_set(datadog_php_logger *, datadog_php_log_level);
+
+/**
+ * Converts `val` to a recognized log level.
+ * Returns `DATADOG_PROFILER_LOG_UNKNOWN` if it does not recognize a level.
+ * Accepted strings are the following, comparison is case insensitive:
+ *   "" (defaults to off), "off", "error", "warn", "info", "debug"
+ * @param val
+ * @return The detected log_level (may be DATADOG_PROFILER_LOG_UNKNOWN).
+ */
+datadog_php_log_level datadog_php_log_level_detect(datadog_php_string_view val);
+
+#undef C_STATIC
+
+#endif // DATADOG_PHP_PROFILER_LOG_H

--- a/components/log/tests/CMakeLists.txt
+++ b/components/log/tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(test-datadog-php-log log.cc)
+
+find_package(Threads REQUIRED)
+
+target_link_libraries(test-datadog-php-log
+  PRIVATE Catch2::Catch2WithMain datadog-php-log datadog_php_string_view Threads::Threads
+)
+
+catch_discover_tests(test-datadog-php-log)

--- a/components/log/tests/log.cc
+++ b/components/log/tests/log.cc
@@ -1,0 +1,73 @@
+extern "C" {
+#include <components/log/log.h>
+}
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <catch2/catch.hpp>
+#include <cerrno>
+#include <climits>
+#include <cstring>
+
+int generate_memfd(void **mem, size_t len) {
+  if (len > INT_MAX)
+    return -1;
+
+  FILE *file = tmpfile();
+  int fd = fileno(file);
+  *mem = nullptr;
+  if (fd != -1) {
+    // int cast is guarded above
+    if (ftruncate(fd, (int)len)) {
+      fclose(file);
+      return -1;
+    }
+
+    int prot = PROT_READ | PROT_WRITE;
+    int flags = MAP_SHARED | MAP_FILE;
+    *mem = mmap(nullptr, len, prot, flags, fd, 0);
+    if (*mem == MAP_FAILED) {
+      fprintf(stderr, "%s\n", strerror(errno));
+      *mem = nullptr;
+      fclose(file);
+      return -1;
+    }
+  }
+  return fd;
+}
+
+TEST_CASE("logv", "[log]") {
+  char *mem;
+  size_t mem_len = 32;
+  int fd = generate_memfd((void **)&mem, mem_len);
+  REQUIRE(fd != -1);
+  REQUIRE(mem);
+  REQUIRE(mem != MAP_FAILED);
+
+  pthread_mutex_t mutex;
+  REQUIRE(pthread_mutex_init(&mutex, nullptr) == 0);
+
+  datadog_php_logger logger = DATADOG_PHP_LOGGER_INIT;
+  REQUIRE(datadog_php_logger_ctor(&logger, fd, DATADOG_PHP_LOG_DEBUG, &mutex));
+
+  datadog_php_string_view messages[3] = {
+      {datadog_php_string_view_from_cstr("[Datadog Profiling] ")},
+      {datadog_php_string_view_from_cstr("Stack Collector failed to join; ")},
+      {datadog_php_string_view_from_cstr("EDEADLK")},
+  };
+  auto written = datadog_php_logv(&logger, DATADOG_PHP_LOG_ERROR, 3, messages);
+  CHECK(written >= 0);
+
+  auto expect = datadog_php_string_view_from_cstr(
+      "[Datadog Profiling] Stack Collector failed to join; EDEADLK\n");
+  auto actual = datadog_php_string_view{static_cast<size_t>(written), mem};
+  CHECK(datadog_php_string_view_equal(expect, actual));
+
+  datadog_php_logger_dtor(&logger);
+  CHECK(munmap(mem, mem_len) == 0);
+  CHECK(close(fd) == 0);
+  CHECK(pthread_mutex_destroy(&mutex) == 0);
+}

--- a/components/queue/CMakeLists.txt
+++ b/components/queue/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(datadog-php-queue queue.c)
+target_include_directories(datadog-php-queue
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+target_compile_features(datadog-php-queue
+  INTERFACE c_std_99
+  PRIVATE c_std_11
+)
+
+if (DATADOG_PHP_TESTING)
+  add_subdirectory(tests)
+endif ()

--- a/components/queue/queue.c
+++ b/components/queue/queue.c
@@ -1,0 +1,38 @@
+#include "queue.h"
+
+bool datadog_php_queue_try_push(datadog_php_queue *queue, void *item) {
+  if (queue->size == queue->capacity) {
+    return false;
+  }
+  ++queue->size;
+  queue->buffer[queue->head] = item;
+  queue->head = (queue->head + 1) % queue->capacity;
+  return true;
+}
+
+bool datadog_php_queue_try_pop(datadog_php_queue *queue, void **item_ref) {
+  bool has_item = queue->size;
+  if (has_item) {
+    *item_ref = queue->buffer[queue->tail];
+    --queue->size;
+    queue->tail = (queue->tail + 1) % queue->capacity;
+  }
+  return has_item;
+}
+
+bool datadog_php_queue_ctor(datadog_php_queue *queue, uint16_t capacity,
+                            void *buffer[static capacity]) {
+  if (!queue || (capacity && !buffer)) {
+    return false;
+  }
+
+  datadog_php_queue q = {
+      .size = 0,
+      .capacity = capacity,
+      .head = 0,
+      .tail = 0,
+      .buffer = buffer,
+  };
+  *queue = q;
+  return true;
+}

--- a/components/queue/queue.h
+++ b/components/queue/queue.h
@@ -1,0 +1,38 @@
+#ifndef DATADOG_PHP_QUEUE_H
+#define DATADOG_PHP_QUEUE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#if __cplusplus
+#define C_STATIC(...)
+#else
+#define C_STATIC(...) static __VA_ARGS__
+#endif
+
+/**
+ * A bounded, NOT thread-safe queue.
+ * If you are interested in thread-safety, look at datadog_php_channel.
+ *
+ * Since this is C, ergonomic, data-type generic queues are beyond us.
+ * Instead, we assume the caller will to dtor/free the items in the queue as
+ * necessary.
+ */
+typedef struct datadog_php_queue_s {
+  /* We track size instead of computing it from head and tail so that we can
+   * use all buffer slots for storage.
+   */
+  uint16_t size, capacity;
+  uint16_t head, tail;
+  void **buffer; // borrowed, not owned
+} datadog_php_queue;
+
+bool datadog_php_queue_ctor(datadog_php_queue *queue, uint16_t capacity,
+                            void *buffer[C_STATIC(capacity)]);
+
+bool datadog_php_queue_try_pop(datadog_php_queue *queue, void **item_ref);
+bool datadog_php_queue_try_push(datadog_php_queue *queue, void *item);
+
+#undef C_STATIC
+
+#endif // DATADOG_PHP_QUEUE_H

--- a/components/queue/tests/CMakeLists.txt
+++ b/components/queue/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(test-datadog-php-queue queue.cc)
+target_link_libraries(test-datadog-php-queue
+  PRIVATE Catch2::Catch2WithMain datadog-php-queue
+)
+
+catch_discover_tests(test-datadog-php-queue)

--- a/components/queue/tests/queue.cc
+++ b/components/queue/tests/queue.cc
@@ -1,0 +1,57 @@
+extern "C" {
+#include <components/queue/queue.h>
+}
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("empty queue operations", "[queue]") {
+  datadog_php_queue queue;
+  REQUIRE(datadog_php_queue_ctor(&queue, 0, nullptr));
+
+  void *item = nullptr;
+  REQUIRE(!datadog_php_queue_try_push(&queue, item));
+  REQUIRE(!datadog_php_queue_try_pop(&queue, &item));
+}
+
+TEST_CASE("basic queue operations", "[queue]") {
+  datadog_php_queue queue;
+  constexpr const unsigned n = 4;
+  void *buffer[n];
+  REQUIRE(datadog_php_queue_ctor(&queue, n, buffer));
+
+  // we are just pushing in addresses; these values never get dereferenced
+  void *item;
+  void *items[n];
+
+  // by iterating a few times, we may have wrapped (depending on impl)
+  for (unsigned i = 0; i != n; ++i) {
+    REQUIRE(datadog_php_queue_try_push(&queue, items + 0));
+    REQUIRE(datadog_php_queue_try_push(&queue, items + 1));
+    REQUIRE(datadog_php_queue_try_push(&queue, items + 2));
+    REQUIRE(datadog_php_queue_try_push(&queue, items + 3));
+
+    REQUIRE(datadog_php_queue_try_pop(&queue, &item));
+    REQUIRE(item == items + 0);
+
+    REQUIRE(datadog_php_queue_try_pop(&queue, &item));
+    REQUIRE(item == items + 1);
+
+    REQUIRE(datadog_php_queue_try_pop(&queue, &item));
+    REQUIRE(item == items + 2);
+
+    REQUIRE(datadog_php_queue_try_pop(&queue, &item));
+    REQUIRE(item == items + 3);
+  }
+}
+
+TEST_CASE("full queue push", "[queue]") {
+  datadog_php_queue queue;
+  constexpr const unsigned n = 1;
+  void *buffer[n];
+  REQUIRE(datadog_php_queue_ctor(&queue, n, buffer));
+
+  void *items[n];
+
+  REQUIRE(datadog_php_queue_try_push(&queue, items + 0));
+  REQUIRE(!datadog_php_queue_try_push(&queue, items + 0));
+}

--- a/components/sapi/CMakeLists.txt
+++ b/components/sapi/CMakeLists.txt
@@ -1,0 +1,33 @@
+add_library(datadog_php_sapi sapi.c)
+
+target_include_directories(datadog_php_sapi
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_compile_features(datadog_php_sapi
+  PUBLIC c_std_99
+)
+
+set_target_properties(datadog_php_sapi PROPERTIES
+  EXPORT_NAME Sapi
+)
+
+target_link_libraries(datadog_php_sapi
+  PUBLIC Datadog::Php::StringView
+)
+
+add_library(Datadog::Php::Sapi
+  ALIAS datadog_php_sapi
+)
+
+if (${DATADOG_PHP_TESTING})
+  add_subdirectory(tests)
+endif ()
+
+# This copies the include files when `install` is ran
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/sapi.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/sapi/
+)
+

--- a/components/sapi/sapi.c
+++ b/components/sapi/sapi.c
@@ -1,0 +1,39 @@
+#include "sapi.h"
+
+typedef datadog_php_sapi sapi_t;
+typedef datadog_php_string_view string_view_t;
+
+#define SV(cstr) DATADOG_PHP_STRING_VIEW_LITERAL(cstr)
+
+sapi_t datadog_php_sapi_from_name(string_view_t module) {
+  if (!module.ptr || module.len == 0) {
+    return DATADOG_PHP_SAPI_UNKNOWN;
+  }
+
+  struct {
+    string_view_t str;
+    sapi_t type;
+  } sapis[] = {
+      {SV("apache2handler"), DATADOG_PHP_SAPI_APACHE2HANDLER},
+      {SV("cgi-fcgi"), DATADOG_PHP_SAPI_CGI_FCGI},
+      {SV("cli"), DATADOG_PHP_SAPI_CLI},
+      {SV("cli-server"), DATADOG_PHP_SAPI_CLI_SERVER},
+      {SV("embed"), DATADOG_PHP_SAPI_EMBED},
+      {SV("fpm-fcgi"), DATADOG_PHP_SAPI_FPM_FCGI},
+      {SV("litespeed"), DATADOG_PHP_SAPI_LITESPEED},
+      {SV("phpdbg"), DATADOG_PHP_SAPI_PHPDBG},
+  };
+
+  unsigned n_sapis = sizeof sapis / sizeof *sapis;
+  for (unsigned i = 0; i != n_sapis; ++i) {
+    if (datadog_php_string_view_equal(module, sapis[i].str)) {
+      return sapis[i].type;
+    }
+  }
+
+  return DATADOG_PHP_SAPI_UNKNOWN;
+}
+
+datadog_php_sapi datadog_php_sapi_detect(datadog_php_string_view module) {
+  return datadog_php_sapi_from_name(module);
+}

--- a/components/sapi/sapi.h
+++ b/components/sapi/sapi.h
@@ -1,0 +1,21 @@
+#ifndef DATADOG_PHP_SAPI_H
+#define DATADOG_PHP_SAPI_H
+
+#include <components/string_view/string_view.h>
+
+typedef enum {
+  DATADOG_PHP_SAPI_UNKNOWN = 0,
+  DATADOG_PHP_SAPI_APACHE2HANDLER,
+  DATADOG_PHP_SAPI_CGI_FCGI,
+  DATADOG_PHP_SAPI_CLI,
+  DATADOG_PHP_SAPI_CLI_SERVER,
+  DATADOG_PHP_SAPI_EMBED,
+  DATADOG_PHP_SAPI_LITESPEED,
+  DATADOG_PHP_SAPI_FPM_FCGI,
+  DATADOG_PHP_SAPI_PHPDBG,
+} datadog_php_sapi;
+
+datadog_php_sapi datadog_php_sapi_from_name(datadog_php_string_view module);
+datadog_php_sapi datadog_php_sapi_detect(datadog_php_string_view module);
+
+#endif // DATADOG_PHP_SAPI_H

--- a/components/sapi/tests/CMakeLists.txt
+++ b/components/sapi/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(sapi sapi.cc)
+
+target_link_libraries(sapi
+  PUBLIC Catch2::Catch2WithMain Datadog::Php::Sapi
+)
+
+catch_discover_tests(sapi)

--- a/components/sapi/tests/sapi.cc
+++ b/components/sapi/tests/sapi.cc
@@ -1,0 +1,56 @@
+extern "C" {
+#include <components/sapi/sapi.h>
+}
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("recognize real sapis", "[sapi]") {
+  // these strings were taken from the PHP 8.0's sapi/ folder
+  struct {
+    const char *name;
+    datadog_php_sapi sapi;
+  } servers[] = {
+      {"apache2handler", DATADOG_PHP_SAPI_APACHE2HANDLER},
+      {"cgi-fcgi", DATADOG_PHP_SAPI_CGI_FCGI},
+      {"cli", DATADOG_PHP_SAPI_CLI},
+      {"cli-server", DATADOG_PHP_SAPI_CLI_SERVER},
+      {"embed", DATADOG_PHP_SAPI_EMBED},
+      {"fpm-fcgi", DATADOG_PHP_SAPI_FPM_FCGI},
+      {"litespeed", DATADOG_PHP_SAPI_LITESPEED},
+      {"phpdbg", DATADOG_PHP_SAPI_PHPDBG},
+  };
+
+  for (auto server : servers) {
+    datadog_php_string_view view =
+        datadog_php_string_view_from_cstr(server.name);
+    datadog_php_sapi sapi = datadog_php_sapi_from_name(view);
+
+    REQUIRE(sapi == server.sapi);
+  }
+}
+
+TEST_CASE("unknown sapis", "[sapi]") {
+  /* These used to be SAPIs, but have since been removed. I think that makes
+   * them good testing candidates for unknown SAPIs.
+   */
+  const char *servers[] = {
+      "aolserver",
+      "caudium",
+
+      // "Continuity" being upper-cased gave me a giggle, as all others aren't
+      "Continuity",
+
+      "isapi",
+      "nsapi",
+      "pi3web",
+      "roxen",
+      "webjames",
+  };
+
+  for (auto server : servers) {
+    datadog_php_string_view view = datadog_php_string_view_from_cstr(server);
+    datadog_php_sapi sapi = datadog_php_sapi_from_name(view);
+
+    REQUIRE(sapi == DATADOG_PHP_SAPI_UNKNOWN);
+  }
+}

--- a/components/stack-sample/CMakeLists.txt
+++ b/components/stack-sample/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(datadog-php-stack-sample OBJECT stack-sample.c stack-sample.h)
+
+target_include_directories(datadog-php-stack-sample
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+target_compile_features(datadog-php-stack-sample PUBLIC c_std_11)
+
+target_link_libraries(datadog-php-stack-sample PUBLIC datadog_php_string_view)
+
+if (DATADOG_PHP_TESTING)
+  add_subdirectory(tests)
+endif ()

--- a/components/stack-sample/stack-sample.c
+++ b/components/stack-sample/stack-sample.c
@@ -1,0 +1,133 @@
+#include "stack-sample.h"
+
+#include <string.h>
+
+/* Done in the impl instead of the header because on CentOS 6 in gnu++11 mode
+ * it fails in the header. The header gets included in C++ mode for testing. */
+_Static_assert(sizeof(struct datadog_php_stack_sample_s) < 8192u,
+               "size of datadog_php_stack_sample should be less than 8KiB");
+
+typedef datadog_php_stack_sample stack_sample_t;
+typedef datadog_php_stack_sample_frame stack_sample_frame_t;
+typedef datadog_php_stack_sample_iterator stack_sample_iterator_t;
+typedef datadog_php_string_view string_view_t;
+
+static void stack_sample_default_ctor(stack_sample_t *sample) {
+  memset(sample, 0, sizeof *sample);
+
+  // we store an empty string with null terminator at position 0
+  sample->buffer_len = 1;
+}
+
+void datadog_php_stack_sample_ctor(datadog_php_stack_sample *sample) {
+  stack_sample_default_ctor(sample);
+}
+
+uint16_t
+datadog_php_stack_sample_depth(const datadog_php_stack_sample *sample) {
+  return sample->depth;
+}
+
+void datadog_php_stack_sample_dtor(datadog_php_stack_sample *sample) {
+  stack_sample_default_ctor(sample);
+}
+
+static bool try_add_string(stack_sample_t *sample, string_view_t string,
+                           uint16_t *offset) {
+  // we pack all empty strings into offset 0
+  if (string.len == 0) {
+    *offset = 0;
+    return true;
+  }
+
+  // ensure there is room for the string
+  if (sample->buffer_len + string.len + 1 <= sizeof(sample->buffer)) {
+    uint16_t off = sample->buffer_len;
+    memcpy(&sample->buffer[off], string.ptr, string.len);
+
+    // null-terminate the string; we rely on ctor's memzero for this and just +1
+    sample->buffer_len += string.len + 1;
+    *offset = off;
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool datadog_php_stack_sample_try_add(stack_sample_t *sample,
+                                      stack_sample_frame_t frame) {
+  uint16_t depth = sample->depth;
+  if (depth >= datadog_php_stack_sample_max_depth) {
+    return false;
+  }
+
+  uint16_t function_off;
+  if (!try_add_string(sample, frame.function, &function_off)) {
+    return false;
+  }
+  sample->function_off[depth] = function_off;
+  sample->function_len[depth] = frame.function.len;
+
+  uint16_t file_off;
+  if (!try_add_string(sample, frame.file, &file_off)) {
+    return false;
+  }
+  sample->file_off[depth] = file_off;
+  sample->file_len[depth] = frame.file.len;
+
+  sample->lineno[depth] = frame.lineno;
+  ++sample->depth;
+
+  return true;
+}
+
+stack_sample_iterator_t
+datadog_php_stack_sample_iterator_ctor(const stack_sample_t *sample) {
+  stack_sample_iterator_t iterator = {
+      .sample = sample,
+      .depth = 0,
+  };
+  return iterator;
+}
+
+void datadog_php_stack_sample_iterator_dtor(stack_sample_iterator_t *iterator) {
+  iterator->sample = NULL;
+  iterator->depth = 0;
+}
+
+void datadog_php_stack_sample_iterator_rewind(
+    stack_sample_iterator_t *iterator) {
+  iterator->depth = 0;
+}
+
+bool datadog_php_stack_sample_iterator_valid(
+    stack_sample_iterator_t *iterator) {
+  return iterator->sample && iterator->depth < iterator->sample->depth;
+}
+
+uint16_t datadog_php_stack_sample_iterator_depth(
+    const stack_sample_iterator_t *iterator) {
+  return iterator->depth;
+}
+
+stack_sample_frame_t
+datadog_php_stack_sample_iterator_frame(stack_sample_iterator_t *iterator) {
+  const stack_sample_t *sample = iterator->sample;
+  uint16_t depth = iterator->depth;
+
+  const char *function = &sample->buffer[sample->function_off[depth]];
+  size_t function_len = sample->function_len[depth];
+
+  const char *file = &sample->buffer[sample->file_off[depth]];
+  size_t file_len = sample->file_len[depth];
+  stack_sample_frame_t frame = {
+      .function = {function_len, function},
+      .file = {file_len, file},
+      .lineno = sample->lineno[depth],
+  };
+  return frame;
+}
+
+void datadog_php_stack_sample_iterator_next(stack_sample_iterator_t *iterator) {
+  ++iterator->depth;
+}

--- a/components/stack-sample/stack-sample.h
+++ b/components/stack-sample/stack-sample.h
@@ -1,0 +1,82 @@
+#ifndef DATADOG_PHP_STACK_SAMPLE_H
+#define DATADOG_PHP_STACK_SAMPLE_H
+
+#include <components/string_view/string_view.h>
+#include <stdint.h>
+
+#define DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH 99u
+static const uint16_t datadog_php_stack_sample_max_depth =
+    DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH;
+
+/**
+ * A stack sample represents a stack sample in a serialized form that is not
+ * aware of any language runtime specific things. This layout could be more
+ * efficient. Each frame holds the function/method name, file, and line. Not all
+ * frames will have all members.
+ *
+ * Treat this as opaque so as it's easier to test structure-of-arrays vs
+ * array-of-structures and other layout optimizations.
+ */
+typedef struct datadog_php_stack_sample_s {
+  uint16_t depth;
+  uint16_t buffer_len;
+
+  /* We save quite a bit of space by using offsets into the buffer instead of
+   * storing full pointers (16 bit vs 64 bit).
+   * We leave room for 1 more frame than datadog_php_stack_sample_max_depth for
+   * a summary frame ($x more frames).
+   */
+  uint16_t function_off[DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1];
+  uint16_t function_len[DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1];
+  uint16_t file_off[DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1];
+  uint16_t file_len[DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1];
+  int64_t lineno[DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1];
+
+  /* The strings need to point into this buffer. It's sized so that there are
+   * 64 bytes per entry, which on average may not be enough, but does allow for
+   * deeper stacks if the function and file names are on the shorter side.
+   */
+  char buffer[(DATADOG_PHP_STACK_SAMPLE_MAX_DEPTH + 1) * 64u];
+} datadog_php_stack_sample;
+
+typedef struct datadog_php_stack_sample_frame_s {
+  datadog_php_string_view function;
+  datadog_php_string_view file;
+  int64_t lineno;
+} datadog_php_stack_sample_frame;
+
+void datadog_php_stack_sample_ctor(datadog_php_stack_sample *);
+uint16_t datadog_php_stack_sample_depth(const datadog_php_stack_sample *sample);
+void datadog_php_stack_sample_dtor(datadog_php_stack_sample *);
+
+bool datadog_php_stack_sample_try_add(datadog_php_stack_sample *,
+                                      datadog_php_stack_sample_frame);
+
+/**
+ * A stack sample iterator can be used to iterate across a sample, re-assembling
+ * each frame from its serialized layout.
+ */
+typedef struct datadog_php_stack_sample_iterator {
+  const datadog_php_stack_sample *sample;
+  uint16_t depth;
+} datadog_php_stack_sample_iterator;
+
+datadog_php_stack_sample_iterator
+datadog_php_stack_sample_iterator_ctor(const datadog_php_stack_sample *);
+
+void datadog_php_stack_sample_iterator_dtor(
+    datadog_php_stack_sample_iterator *iterator);
+
+bool datadog_php_stack_sample_iterator_valid(
+    datadog_php_stack_sample_iterator *iterator);
+
+uint16_t datadog_php_stack_sample_iterator_depth(
+    const datadog_php_stack_sample_iterator *iterator);
+
+datadog_php_stack_sample_frame datadog_php_stack_sample_iterator_frame(
+    datadog_php_stack_sample_iterator *iterator);
+
+void datadog_php_stack_sample_iterator_next(
+    datadog_php_stack_sample_iterator *iterator);
+
+#endif // DATADOG_PHP_STACK_SAMPLE_H

--- a/components/stack-sample/tests/CMakeLists.txt
+++ b/components/stack-sample/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(test-datadog-php-stack-sample stack-sample.cc)
+target_link_libraries(test-datadog-php-stack-sample
+  PRIVATE Catch2::Catch2WithMain datadog-php-stack-sample datadog_php_string_view
+)
+
+catch_discover_tests(test-datadog-php-stack-sample)

--- a/components/stack-sample/tests/stack-sample.cc
+++ b/components/stack-sample/tests/stack-sample.cc
@@ -1,0 +1,64 @@
+extern "C" {
+#include <components/stack-sample/stack-sample.h>
+#include <components/string_view/string_view.h>
+}
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("empty ctor and dtor", "[stack-sample]") {
+  datadog_php_stack_sample sample;
+  datadog_php_stack_sample_ctor(&sample);
+
+  CHECK(datadog_php_stack_sample_depth(&sample) == 0u);
+
+  datadog_php_stack_sample_dtor(&sample);
+}
+
+TEST_CASE("empty iterator ctor and dtor", "[stack-sample]") {
+  datadog_php_stack_sample sample;
+  datadog_php_stack_sample_ctor(&sample);
+
+  datadog_php_stack_sample_iterator iterator =
+      datadog_php_stack_sample_iterator_ctor(&sample);
+
+  CHECK(datadog_php_stack_sample_iterator_depth(&iterator) == 0u);
+
+  for (iterator = datadog_php_stack_sample_iterator_ctor(&sample);
+       datadog_php_stack_sample_iterator_valid(&iterator);
+       datadog_php_stack_sample_iterator_next(&iterator)) {}
+
+  CHECK(datadog_php_stack_sample_iterator_depth(&iterator) == 0u);
+
+  datadog_php_stack_sample_iterator_dtor(&iterator);
+  datadog_php_stack_sample_dtor(&sample);
+}
+
+TEST_CASE("iterator", "[stack-sample]") {
+  datadog_php_stack_sample sample;
+  datadog_php_stack_sample_ctor(&sample);
+
+  const datadog_php_stack_sample_frame main_frame = {
+      datadog_php_string_view_from_cstr("{main}"),
+      datadog_php_string_view_from_cstr("/srv/public/index.php"), 3};
+  CHECK(datadog_php_stack_sample_try_add(&sample, main_frame));
+
+  CHECK(datadog_php_stack_sample_depth(&sample) == 1u);
+
+  auto iterator = datadog_php_stack_sample_iterator_ctor(&sample);
+
+  CHECK(datadog_php_stack_sample_iterator_depth(&iterator) == 0u);
+
+  for (iterator = datadog_php_stack_sample_iterator_ctor(&sample);
+       datadog_php_stack_sample_iterator_valid(&iterator);
+       datadog_php_stack_sample_iterator_next(&iterator)) {
+    auto frame = datadog_php_stack_sample_iterator_frame(&iterator);
+    CHECK(datadog_php_string_view_equal(frame.function, main_frame.function));
+    CHECK(datadog_php_string_view_equal(frame.file, main_frame.file));
+    CHECK(frame.lineno == main_frame.lineno);
+  }
+
+  CHECK(datadog_php_stack_sample_iterator_depth(&iterator) == 1u);
+
+  datadog_php_stack_sample_iterator_dtor(&iterator);
+  datadog_php_stack_sample_dtor(&sample);
+}

--- a/components/string_view/CMakeLists.txt
+++ b/components/string_view/CMakeLists.txt
@@ -1,0 +1,29 @@
+add_library(datadog_php_string_view string_view.c)
+
+target_include_directories(datadog_php_string_view
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_compile_features(datadog_php_string_view
+  PUBLIC c_std_99
+)
+
+set_target_properties(datadog_php_string_view PROPERTIES
+  EXPORT_NAME StringView
+)
+
+add_library(Datadog::Php::StringView
+  ALIAS datadog_php_string_view
+)
+
+if (${DATADOG_PHP_TESTING})
+  add_subdirectory(tests)
+endif ()
+
+# This copies the include files when `install` is ran
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/string_view.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/string_view/
+)
+

--- a/components/string_view/string_view.c
+++ b/components/string_view/string_view.c
@@ -1,0 +1,16 @@
+#include "string_view.h"
+
+#include <string.h>
+
+datadog_php_string_view datadog_php_string_view_from_cstr(const char *cstr) {
+  if (cstr) {
+    return (datadog_php_string_view){.len = strlen(cstr), .ptr = cstr};
+  } else {
+    return (datadog_php_string_view){.len = 0, .ptr = ""};
+  }
+}
+
+bool datadog_php_string_view_equal(datadog_php_string_view a,
+                                   datadog_php_string_view b) {
+  return a.len == b.len && (a.ptr == b.ptr || memcmp(a.ptr, b.ptr, b.len) == 0);
+}

--- a/components/string_view/string_view.h
+++ b/components/string_view/string_view.h
@@ -1,0 +1,48 @@
+#ifndef DATADOG_PHP_STRING_VIEW_H
+#define DATADOG_PHP_STRING_VIEW_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/**
+ * A string view is a non-owning view into another string. The original string
+ * should not be changed from the view.
+ *
+ * TREAT THIS AS OPAQUE, even though it is not! Use the macros and functions to
+ * initialize this struct; DO NOT memzero or rely on defaults like = {} to init
+ * this, because we need to guarantee `ptr` is not null to avoid undefined
+ * behavior.
+ */
+typedef struct datadog_php_string_view {
+  size_t len;
+  const char *ptr; // must not be null; use "" for empty string
+  // it would be great if nonnull attribute worked on struct fields
+} datadog_php_string_view;
+
+/* Used to initialize an empty string e.g.
+ *   datadog_php_string_view str = DATADOG_PHP_STRING_VIEW_INIT;
+ */
+#define DATADOG_PHP_STRING_VIEW_INIT                                           \
+  { 0, "" }
+
+/* Initialize from a string literal e.g.
+ *   datadog_php_string_view str = DATADOG_PHP_STRING_VIEW_LITERAL("hello");
+ */
+#define DATADOG_PHP_STRING_VIEW_LITERAL(cstr)                                  \
+  { sizeof(cstr) - 1, cstr }
+
+/**
+ * Converts the C string `cstr` into a string view by getting its length from
+ * `strlen`. Null is permitted and will become an empty string.
+ * @param cstr May be nullptr.
+ */
+datadog_php_string_view datadog_php_string_view_from_cstr(const char *cstr);
+
+/**
+ * Compares the views `a` and `b` for equality. Note that the `.ptr` value of
+ * the views will be ignored when `.len` is 0.
+ */
+bool datadog_php_string_view_equal(datadog_php_string_view a,
+                                   datadog_php_string_view b);
+
+#endif // DATADOG_PHP_STRING_VIEW_H

--- a/components/string_view/tests/CMakeLists.txt
+++ b/components/string_view/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(string_view string_view.cc)
+
+target_link_libraries(string_view
+  PUBLIC Catch2::Catch2WithMain Datadog::Php::StringView
+)
+
+catch_discover_tests(string_view)

--- a/components/string_view/tests/string_view.cc
+++ b/components/string_view/tests/string_view.cc
@@ -1,0 +1,88 @@
+extern "C" {
+#include <components/string_view/string_view.h>
+}
+
+#include <catch2/catch.hpp>
+#include <cstring>
+
+TEST_CASE("string_view init", "[string_view]") {
+  datadog_php_string_view str = DATADOG_PHP_STRING_VIEW_INIT;
+
+  REQUIRE(str.len == 0);
+  REQUIRE(str.ptr);
+}
+
+TEST_CASE("string_view cstrings", "[string_view]") {
+  datadog_php_string_view empty = datadog_php_string_view_from_cstr("");
+  REQUIRE(empty.len == 0);
+  REQUIRE(empty.ptr);
+
+  datadog_php_string_view nil = datadog_php_string_view_from_cstr(nullptr);
+  REQUIRE(nil.len == 0);
+  REQUIRE(nil.ptr);
+
+  datadog_php_string_view abc = datadog_php_string_view_from_cstr("abc");
+  REQUIRE(abc.len == 3);
+  REQUIRE(memcmp(abc.ptr, "abc", 3) == 0);
+
+  const char buff[5] = "four";
+  datadog_php_string_view four = datadog_php_string_view_from_cstr(buff);
+  REQUIRE(four.len == 4);
+  REQUIRE((const void *)four.ptr == (const void *)&buff);
+}
+
+TEST_CASE("string_view empty equal", "[string_view]") {
+  datadog_php_string_view empty = datadog_php_string_view_from_cstr("");
+  REQUIRE(empty.len == 0);
+  REQUIRE(empty.ptr);
+
+  datadog_php_string_view nil = datadog_php_string_view_from_cstr(nullptr);
+  REQUIRE(nil.len == 0);
+  REQUIRE(nil.ptr);
+
+  REQUIRE(datadog_php_string_view_equal(empty, nil));
+}
+
+TEST_CASE("string_view equal", "[string_view]") {
+  const char buff1[] = "asdf";
+  char buff2[sizeof buff1];
+  memcpy((void *)buff2, buff1, sizeof buff1);
+
+  datadog_php_string_view str1 = datadog_php_string_view_from_cstr(buff1);
+  datadog_php_string_view str2 = datadog_php_string_view_from_cstr(buff2);
+
+  REQUIRE(datadog_php_string_view_equal(str1, str2));
+
+  // identity cases
+  CHECK(datadog_php_string_view_equal(str1, str1));
+  CHECK(datadog_php_string_view_equal(str2, str2));
+
+  char a[] = "aBcDE01234";
+  char b[] = "abcde01234";
+
+  auto x = datadog_php_string_view_from_cstr(a);
+  auto y = datadog_php_string_view_from_cstr(b);
+  CHECK(!datadog_php_string_view_equal(x, y));
+
+  for (auto &ch : a) {
+    ch = (char)(unsigned char)tolower((unsigned char)ch);
+  }
+
+  CHECK(datadog_php_string_view_equal(x, y));
+}
+
+TEST_CASE("string_view equal different lengths", "[string_view]") {
+  char a[] = "aBcDE0";
+  char b[] = "abcde01234";
+
+  auto x = datadog_php_string_view_from_cstr(a);
+  auto y = datadog_php_string_view_from_cstr(b);
+  CHECK(!datadog_php_string_view_equal(x, y));
+
+  for (auto &ch : a) {
+    ch = (char)(unsigned char)tolower((unsigned char)ch);
+  }
+
+  // still not equal after lower-casing
+  CHECK(!datadog_php_string_view_equal(x, y));
+}

--- a/components/time/CMakeLists.txt
+++ b/components/time/CMakeLists.txt
@@ -1,0 +1,75 @@
+add_library(datadog-php-time OBJECT time.c time.h)
+
+target_include_directories(datadog-php-time
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+include(CheckCSourceRuns)
+include(CMakePushCheckState)
+
+find_package(Threads)
+
+#[[ Prior to glibc 2.17, librt was required for clock_gettime.
+    Check for it without flags first.
+    clock_gettime gets used with pthread_getcpuclockid if the platform has it.
+]]
+cmake_push_check_state(RESET)
+set(CLOCK_GETTIME_PROGRAM "#include <time.h>
+int main(void) {
+  struct timespec ts;
+  return clock_gettime(CLOCK_REALTIME, &ts) == 0 ? 0 : 1;
+}
+")
+check_c_source_runs("${CLOCK_GETTIME_PROGRAM}" DATADOG_HAVE_CLOCK_GETTIME)
+cmake_pop_check_state()
+
+if (NOT DATADOG_HAVE_CLOCK_GETTIME)
+  # Try again with -lrt; use a different cache variable name or it won't run.
+  cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_LIBRARIES -lrt)
+  check_c_source_runs("${CLOCK_GETTIME_PROGRAM}" DATADOG_HAVE_CLOCK_GETTIME_RT)
+
+  if (DATADOG_HAVE_CLOCK_GETTIME_RT)
+    target_link_libraries(datadog-php-time PRIVATE -lrt)
+  endif ()
+  cmake_pop_check_state()
+endif ()
+
+if (DATADOG_HAVE_CLOCK_GETTIME OR DATADOG_HAVE_CLOCK_GETTIME_RT)
+  target_compile_definitions(datadog-php-time PRIVATE -DDATADOG_HAVE_CLOCK_GETTIME=1)
+
+  cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_LIBRARIES Threads::Threads)
+  check_c_source_runs("
+  #include <pthread.h>
+  #include <time.h>
+
+  int main(void) {
+    clockid_t clockid;
+    // consider the fact the API exists good enough; it may still fail at runtime,
+    // and that's okay; it just needs to exist.
+    (void)pthread_getcpuclockid(pthread_self(), &clockid);
+    return 0;
+  }
+  " DATADOG_HAVE_PTHREAD_GETCPUCLOCKID)
+  if (DATADOG_HAVE_PTHREAD_GETCPUCLOCKID)
+    target_compile_definitions(datadog-php-time PRIVATE -DDATADOG_HAVE_PTHREAD_GETCPUCLOCKID=1)
+  endif ()
+  cmake_pop_check_state()
+endif ()
+
+check_c_source_runs("#include <mach/mach_init.h>
+#include <mach/thread_act.h>
+
+int main(void) {
+	mach_port_t thread = mach_thread_self();
+	mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+	thread_basic_info_data_t info;
+	(void)thread_info(thread, THREAD_BASIC_INFO, (thread_info_t) &info, &count);
+	return 0;
+}
+" DATADOG_HAVE_THREAD_INFO)
+
+if (DATADOG_HAVE_THREAD_INFO)
+  target_compile_definitions(datadog-php-time PRIVATE -DDATADOG_HAVE_THREAD_INFO=1)
+endif ()

--- a/components/time/time.c
+++ b/components/time/time.c
@@ -1,0 +1,66 @@
+#include "time.h"
+
+#if DATADOG_HAVE_PTHREAD_GETCPUCLOCKID
+
+#include <errno.h>
+#include <pthread.h>
+#include <string.h>
+
+datadog_php_cpu_time_result datadog_php_cpu_time_now(void) {
+  struct timespec timespec;
+  clockid_t clockid; //  todo: cache this?
+
+  if (pthread_getcpuclockid(pthread_self(), &clockid)) {
+    return (datadog_php_cpu_time_result){
+        .tag = DATADOG_PHP_CPU_TIME_ERR,
+        .err = strerror(errno),
+    };
+  }
+
+  if (clock_gettime(clockid, &timespec)) {
+    return (datadog_php_cpu_time_result){
+        .tag = DATADOG_PHP_CPU_TIME_ERR,
+        .err = strerror(errno),
+    };
+  }
+
+  return (datadog_php_cpu_time_result){
+      .tag = DATADOG_PHP_CPU_TIME_OK,
+      .ok = timespec,
+  };
+}
+
+#elif DATADOG_HAVE_THREAD_INFO
+
+#include <mach/mach_error.h>
+#include <mach/mach_init.h>
+#include <mach/thread_act.h>
+
+datadog_php_cpu_time_result datadog_php_cpu_time_now(void) {
+  mach_port_t thread = mach_thread_self();
+  mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+  thread_basic_info_data_t info;
+  kern_return_t kr =
+      thread_info(thread, THREAD_BASIC_INFO, (thread_info_t)&info, &count);
+
+  if (kr != KERN_SUCCESS) {
+    return (datadog_php_cpu_time_result){
+        .tag = DATADOG_PHP_CPU_TIME_ERR,
+        .err = mach_error_string(kr),
+    };
+  }
+
+  struct timespec timespec = {
+      .tv_sec = info.user_time.seconds + info.system_time.seconds,
+      .tv_nsec =
+          (info.user_time.microseconds + info.system_time.microseconds) * 1000,
+  };
+  return (datadog_php_cpu_time_result){
+      .tag = DATADOG_PHP_CPU_TIME_OK,
+      .ok = timespec,
+  };
+}
+
+#else
+#error Unhandled platform for cpu time
+#endif

--- a/components/time/time.h
+++ b/components/time/time.h
@@ -1,0 +1,28 @@
+#ifndef DATADOG_PHP_SYSTEM_TIME_H
+#define DATADOG_PHP_SYSTEM_TIME_H
+
+#include <stdint.h>
+#include <time.h>
+
+/* This component exists to paper over differences in time across platforms.
+ * In the past, this included monotonic, system, and cpu time. It seems feasible
+ * that we would re-introduce those other types, so I left the name as a
+ * generic "time" component instead of renaming to cpu-time.
+ */
+
+typedef enum datadog_php_cpu_time_result_tag {
+  DATADOG_PHP_CPU_TIME_OK,
+  DATADOG_PHP_CPU_TIME_ERR,
+} datadog_php_cpu_time_result_tag;
+
+typedef struct datadog_php_cpu_time_result_s {
+  datadog_php_cpu_time_result_tag tag;
+  union {
+    struct timespec ok;
+    const char *err; // c-string describing error; static lifetime
+  };
+} datadog_php_cpu_time_result;
+
+datadog_php_cpu_time_result datadog_php_cpu_time_now(void);
+
+#endif // DATADOG_PHP_SYSTEM_TIME_H

--- a/datadog-profiling.c
+++ b/datadog-profiling.c
@@ -1,0 +1,56 @@
+#include "profiling/php_datadog-profiling.h"
+
+#include <php.h>
+
+ZEND_COLD int datadog_profiling_hybrid_startup(zend_extension *extension);
+
+/* This is used by the engine to ensure that the extension is built against
+ * the same version as the engine. It must be named `extension_version_info`.
+ */
+ZEND_API zend_extension_version_info extension_version_info = {
+    .zend_extension_api_no = ZEND_EXTENSION_API_NO,
+    .build_id = ZEND_EXTENSION_BUILD_ID,
+};
+
+/* This must be named `zend_extension_entry` for the engine to know this is a
+ * zend extension.
+ */
+ZEND_API zend_extension zend_extension_entry = {
+    .name = "datadog-profiling",
+    .version = PHP_DATADOG_PROFILING_VERSION,
+    .author = "Datadog",
+    .URL = "https://github.com/DataDog/dd-prof-php",
+    .copyright = "Copyright Datadog",
+    .startup = datadog_profiling_hybrid_startup,
+    .activate = datadog_profiling_activate,
+    .deactivate = datadog_profiling_deactivate,
+    .shutdown = datadog_profiling_shutdown,
+    .resource_number = -1,
+};
+
+PHP_MINFO_FUNCTION(datadog_profiling) {
+  (void)zend_module;
+
+  datadog_profiling_diagnostics();
+}
+
+/* Make this a hybrid zendextension-module, which gives us access to the minfo
+ * hook, so we can print diagnostics.
+ */
+static zend_module_entry datadog_profiling_module_entry = {
+    STANDARD_MODULE_HEADER,
+    "datadog-profiling",
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    PHP_MINFO(datadog_profiling),
+    PHP_DATADOG_PROFILING_VERSION,
+    STANDARD_MODULE_PROPERTIES,
+};
+
+ZEND_COLD int datadog_profiling_hybrid_startup(zend_extension *extension) {
+  (void)datadog_profiling_startup(extension);
+  return zend_startup_module(&datadog_profiling_module_entry);
+}

--- a/datadog-profiling.sym
+++ b/datadog-profiling.sym
@@ -1,0 +1,7 @@
+DATADOG_PROFILER_0.1.0 {
+global:
+        zend_extension_entry;
+        extension_version_info;
+local:
+        *;
+};

--- a/profiling/CMakeLists.txt
+++ b/profiling/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(stack-collector)
+

--- a/profiling/datadog-profiling.c
+++ b/profiling/datadog-profiling.c
@@ -1,0 +1,195 @@
+#include "datadog-profiling.h"
+#include "php_datadog-profiling.h"
+
+#include <Zend/zend.h>
+#include <Zend/zend_portability.h>
+#include <main/SAPI.h>
+#include <php.h>
+#include <stdbool.h>
+#include <uv.h>
+
+// must come after php.h
+#include <ext/standard/info.h>
+
+#include "components/log/log.h"
+#include "components/sapi/sapi.h"
+#include "components/string_view/string_view.h"
+#include "plugins/log_plugin/log_plugin.h"
+#include "plugins/recorder_plugin/recorder_plugin.h"
+#include "plugins/stack_collector_plugin/stack_collector_plugin.h"
+
+// These type names are long, let's shorten them up
+typedef datadog_php_log_level log_level_t;
+typedef datadog_php_sapi sapi_t;
+typedef datadog_php_string_view string_view_t;
+
+static uv_once_t first_activate_once = UV_ONCE_INIT;
+
+/**
+ * Diagnose issues such as being unable to reach the agent.
+ */
+void datadog_profiling_diagnostics(void) {
+  php_info_print_table_start();
+  datadog_php_recorder_plugin_diagnose();
+  php_info_print_table_end();
+}
+
+ZEND_TLS bool datadog_profiling_enabled;
+
+/**
+ * Detect whether the profiler should be enabled.
+ * The profiler should be enabled for the CLI SAPI if `value` is a string value
+ * for true.
+ * The profiler should be enabled for other SAPIs unless `value` is a non-empty
+ * string which isn't true.
+ * See datadog_php_string_view_is_boolean_true to know which strings are
+ * considered to be true.
+ * @param value A boolean string value. May be NULL.
+ * @param sapi
+ * @return
+ */
+static bool detect_profiling_enabled(const char *value, sapi_t sapi) {
+  string_view_t enabled = datadog_php_string_view_from_cstr(value);
+  if (datadog_php_string_view_is_boolean_true(enabled))
+    return true;
+  return sapi == DATADOG_PHP_SAPI_CLI ? false : enabled.len == 0;
+}
+
+static void diagnose_profiling_enabled(bool enabled) {
+  const char *string = NULL;
+
+  if (enabled) {
+    string = "[Datadog Profiling] Profiling is enabled.";
+  } else {
+    string = "[Datadog Profiling] Profiling is disabled.";
+  }
+
+  string_view_t message = {strlen(string), string};
+  prof_logger.log(DATADOG_PHP_LOG_INFO, message);
+}
+
+static void sapi_diagnose(sapi_t sapi, datadog_php_string_view pretty_name) {
+
+  switch (sapi) {
+  case DATADOG_PHP_SAPI_APACHE2HANDLER:
+  case DATADOG_PHP_SAPI_CLI:
+  case DATADOG_PHP_SAPI_CLI_SERVER:
+  case DATADOG_PHP_SAPI_CGI_FCGI:
+  case DATADOG_PHP_SAPI_FPM_FCGI: {
+    const char *msg = "[Datadog Profiling] Detected SAPI: ";
+    string_view_t messages[3] = {
+        {strlen(msg), msg},
+        pretty_name,
+        {1, "."},
+    };
+    log_level_t log_level = DATADOG_PHP_LOG_DEBUG;
+    prof_logger.logv(log_level, 3, messages);
+    break;
+  }
+
+  case DATADOG_PHP_SAPI_UNKNOWN:
+  default: {
+    const char *msg = "[Datadog Profiling] SAPI not detected: ";
+    log_level_t log_level = DATADOG_PHP_LOG_WARN;
+    string_view_t messages[3] = {
+        {strlen(msg), msg},
+        pretty_name,
+        {1, "."},
+    };
+    prof_logger.logv(log_level, 3, messages);
+  }
+  }
+}
+
+int datadog_profiling_startup(zend_extension *extension) {
+  datadog_php_stack_collector_startup(extension);
+
+  return SUCCESS;
+}
+
+// todo: extract this common code out of log_plugin, recorder, etc
+#if PHP_VERSION_ID >= 80000
+#define sapi_getenv_compat(name, name_len) sapi_getenv((name), name_len)
+#elif PHP_VERSION_ID >= 70000
+#define sapi_getenv_compat(name, name_len) sapi_getenv((char *)(name), name_len)
+#endif
+
+static void datadog_profiling_first_activate(void) {
+  sapi_t sapi = datadog_php_sapi_detect(
+      datadog_php_string_view_from_cstr(sapi_module.name));
+
+  /* sapi_getenv may or may not include process environment variables.
+   * It will return NULL when it is not found in the possibly synthetic SAPI
+   * environment. Hence, we need to do a getenv() in any case.
+   */
+  bool use_sapi_env = false;
+
+  datadog_php_string_view env_var =
+      datadog_php_string_view_from_cstr("DD_PROFILING_ENABLED");
+  char *value = sapi_getenv_compat(env_var.ptr, env_var.len);
+  if (value) {
+    use_sapi_env = true;
+  } else {
+    value = getenv(env_var.ptr);
+  }
+
+  datadog_profiling_enabled = detect_profiling_enabled(value, sapi);
+
+  if (use_sapi_env) {
+    efree(value);
+  }
+
+  datadog_php_log_plugin_first_activate(datadog_profiling_enabled);
+
+  // Logging plugin must be initialized before diagnosing things
+  diagnose_profiling_enabled(datadog_profiling_enabled);
+  sapi_diagnose(sapi,
+                datadog_php_string_view_from_cstr(sapi_module.pretty_name));
+
+  datadog_php_recorder_plugin_first_activate(datadog_profiling_enabled);
+  datadog_php_stack_collector_first_activate(datadog_profiling_enabled);
+}
+
+void datadog_profiling_activate(void) {
+  uv_once(&first_activate_once, datadog_profiling_first_activate);
+
+  datadog_php_stack_collector_activate();
+}
+
+void datadog_profiling_deactivate(void) {
+  datadog_php_stack_collector_deactivate();
+}
+
+void datadog_profiling_shutdown(zend_extension *extension) {
+  datadog_php_recorder_plugin_shutdown(extension);
+  datadog_php_log_plugin_shutdown(extension);
+}
+
+static void datadog_info_print(const char *str) {
+  php_output_write(str, strlen(str));
+}
+
+void datadog_profiling_info_diagnostics_row(const char *col_a,
+                                            const char *col_b) {
+
+  if (sapi_module.phpinfo_as_text) {
+    php_info_print_table_row(2, col_a, col_b);
+    return;
+  }
+  datadog_info_print("<tr><td class='e'>");
+  datadog_info_print(col_a);
+  datadog_info_print("</td><td class='v'>");
+  datadog_info_print(col_b);
+  datadog_info_print("</td></tr>\n");
+}
+
+bool datadog_php_string_view_is_boolean_true(string_view_t str) {
+  size_t len = str.len;
+  if (len > 0 && len < 5) {
+    const char *truthy[] = {"1", "on", "yes", "true"};
+    // Conveniently, by pure luck len - 1 is the index for that string.
+    return memcmp(str.ptr, truthy[len - 1], len) == 0;
+  } else {
+    return false;
+  }
+}

--- a/profiling/datadog-profiling.h
+++ b/profiling/datadog-profiling.h
@@ -1,0 +1,20 @@
+#ifndef DATADOG_PHP_PROFILING_H
+#define DATADOG_PHP_PROFILING_H
+
+#include <components/string_view/string_view.h>
+#include <stdbool.h>
+
+/**
+ * Returns true if the `str` is equal to one of these values:
+ *   "1", "on", "yes", "true"
+ *
+ * The selected values are common for INI parsers in various languages.
+ * @param str
+ * @return
+ */
+bool datadog_php_string_view_is_boolean_true(datadog_php_string_view str);
+
+void datadog_profiling_info_diagnostics_row(const char *col_a,
+                                            const char *col_b);
+
+#endif // DATADOG_PHP_PROFILING_H

--- a/profiling/datadog-profiling.m4
+++ b/profiling/datadog-profiling.m4
@@ -1,0 +1,94 @@
+PHP_ARG_ENABLE([datadog-profiling],
+  [whether to enable Datadog Continuous Profiler support],
+  [AS_HELP_STRING([--enable-datadog-profiling],
+    [Enable Datadog profiling support])],
+  [no],
+  [no])
+
+PHP_DATADOG_PROFILING_CFLAGS=""
+
+if test $PHP_VERSION_ID -ge 70100 &&  test "$PHP_DATADOG_PROFILING" = "yes"; then
+  dnl When packaging this ourselves, make sure it's the static version!
+  PKG_CHECK_MODULES([LIBUV], [libuv])
+  PHP_EVAL_LIBLINE($LIBUV_LIBS, EXTRA_LDFLAGS)
+  PHP_EVAL_INCLINE($LIBUV_CFLAGS)
+
+  dnl When packaging this ourselves, make sure it's the static version!
+  PKG_CHECK_MODULES([LIBDDPROF_FFI], [ddprof_ffi])
+  PHP_EVAL_LIBLINE($LIBDDPROF_FFI_LIBS, EXTRA_LDFLAGS)
+  PHP_EVAL_INCLINE($LIBDDPROF_FFI_CFLAGS)
+
+  PHP_DATADOG_PROFILING_SOURCES="\
+    components/arena/arena.c \
+    components/channel/channel.c \
+    components/log/log.c \
+    components/queue/queue.c \
+    components/stack-sample/stack-sample.c \
+    components/time/time.c \
+    profiling/datadog-profiling.c \
+    profiling/plugins/log_plugin/log_plugin.c \
+    profiling/plugins/recorder_plugin/recorder_plugin.c \
+    profiling/plugins/stack_collector_plugin/stack_collector_plugin.c \
+    profiling/stack-collector/stack-collector.c \
+   "
+
+  AC_CACHE_CHECK([for pthread_getcpuclockid], ac_cv_pthread_getcpuclockid,
+    [
+      AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM(
+          [[#include <pthread.h>
+            #include <time.h>]],
+          [[clockid_t clockid;
+            // consider the fact the API exists good enough; it may still fail at runtime,
+            // and that's okay; it just needs to exist.
+            (void)pthread_getcpuclockid(pthread_self(), &clockid);
+          ]]
+        )],
+        [ac_cv_pthread_getcpuclockid=yes], [ac_cv_pthread_getcpuclockid=no])
+    ])
+
+  dnl Prior to glibc 2.17, clock_gettime was in librt, but this will not try to link.
+  dnl todo: use AC_RUN_IFELSE instead
+  AC_CACHE_CHECK([for clock_gettime], ac_cv_clock_gettime,
+    [
+      AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM(
+          [[#include <time.h>]],
+          [[struct timespec ts;
+            return clock_gettime(CLOCK_REALTIME, &ts) == 0 ? 0 : 1;]]
+        )],
+        [ac_cv_clock_gettime=yes], [ac_cv_clock_gettime=no])
+    ])
+
+  AC_CACHE_CHECK([for thread_info], ac_cv_thread_info,
+    [
+      AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM(
+          [[#include <mach/mach_init.h>
+            #include <mach/thread_act.h>]],
+          [[mach_port_t thread = mach_thread_self();
+            mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+            thread_basic_info_data_t info;
+            (void)thread_info(thread, THREAD_BASIC_INFO, (thread_info_t) &info, &count);]]
+        )],
+        [ac_cv_thread_info=yes], [ac_cv_thread_info=no])
+    ])
+
+  if test "$ac_cv_pthread_getcpuclockid" = "yes" ; then
+    PHP_DATADOG_PROFILING_CFLAGS="$PHP_DATADOG_PROFILING_CFLAGS -DDATADOG_HAVE_PTHREAD_GETCPUCLOCKID=1"
+  fi
+
+  if test "$ac_cv_clock_gettime" = "yes" ; then
+    PHP_DATADOG_PROFILING_CFLAGS="$PHP_DATADOG_PROFILING_CFLAGS -DDATADOG_HAVE_CLOCK_GETTIME=1"
+  fi
+
+  if test "$ac_cv_thread_info" = "yes" ; then
+    PHP_DATADOG_PROFILING_CFLAGS="$PHP_DATADOG_PROFILING_CFLAGS -DDATADOG_HAVE_THREAD_INFO=1"
+  fi
+
+  have_datadog_profiling=1
+  AC_DEFINE(HAVE_DATADOG_PROFILING, 1, [whether to include the profiler])
+else
+  PHP_DATADOG_PROFILING_SOURCES=""
+  AC_DEFINE(HAVE_DATADOG_PROFILING, 0, [whether to include the profiler])
+fi

--- a/profiling/php_datadog-profiling.h
+++ b/profiling/php_datadog-profiling.h
@@ -1,0 +1,20 @@
+#ifndef PHP_DATADOG_PROFILING_H
+#define PHP_DATADOG_PROFILING_H
+
+#include <php_config.h>
+
+#include <Zend/zend_extensions.h>
+
+#define PHP_DATADOG_PROFILING_VERSION "0.3.0"
+
+int datadog_profiling_startup(zend_extension *);
+void datadog_profiling_activate(void);
+void datadog_profiling_deactivate(void);
+void datadog_profiling_shutdown(zend_extension *);
+void datadog_profiling_diagnostics(void);
+
+#if defined(ZTS)
+ZEND_TSRMLS_CACHE_EXTERN()
+#endif
+
+#endif // PHP_DATADOG_PROFILING_H

--- a/profiling/plugins/log_plugin/log_plugin.c
+++ b/profiling/plugins/log_plugin/log_plugin.c
@@ -1,0 +1,142 @@
+#include "log_plugin.h"
+
+#include <SAPI.h>
+#include <Zend/zend.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+typedef datadog_php_logger logger_t;
+typedef datadog_php_log_level log_level_t;
+typedef datadog_php_string_view string_view_t;
+
+static logger_t profiler_logger = DATADOG_PHP_LOGGER_INIT;
+static pthread_mutex_t logger_mutex;
+
+// Use noop log pattern to avoid initialization issues {{{
+static void noop_log(datadog_php_log_level ll, datadog_php_string_view sv) {
+  (void)ll, (void)sv;
+}
+
+static int64_t noop_logv(datadog_php_log_level level, size_t n_messages,
+                         datadog_php_string_view messages[static n_messages]) {
+  (void)level, (void)n_messages, (void)messages;
+  return -1;
+}
+
+void noop_log_cstr(datadog_php_log_level log_level, const char *cstr) {
+  (void)log_level, (void)cstr;
+}
+
+datadog_php_static_logger prof_logger = {
+    .log = noop_log,
+    .logv = noop_logv,
+    .log_cstr = noop_log_cstr,
+}; // }}}
+
+static void datadog_php_log_plugin_log(log_level_t log_level,
+                                       string_view_t message) {
+  datadog_php_log(&profiler_logger, log_level, message);
+}
+
+/**
+ * @param log_level
+ * @param cstr Must not be null.
+ */
+static void datadog_php_log_plugin_log_cstr(datadog_php_log_level log_level,
+                                            const char *cstr) {
+  string_view_t message = {strlen(cstr), cstr};
+  datadog_php_log(&profiler_logger, log_level, message);
+}
+
+static int64_t datadog_php_log_plugin_logv(
+    datadog_php_log_level level, size_t n_messages,
+    datadog_php_string_view messages[static n_messages]) {
+  return datadog_php_logv(&profiler_logger, level, n_messages, messages);
+}
+
+// todo: extract this to a plugin?
+#if PHP_VERSION_ID >= 80000
+#define sapi_getenv_compat(name, name_len) sapi_getenv((name), name_len)
+#elif PHP_VERSION_ID >= 70000
+#define sapi_getenv_compat(name, name_len) sapi_getenv((char *)(name), name_len)
+#else
+#define sapi_getenv_compat(name, name_len)                                     \
+  sapi_getenv((char *)(name), name_len TSRMLS_CC)
+#endif
+
+static void datadog_php_log_plugin_init(void) {
+  int descriptor = dup(STDERR_FILENO);
+  if (descriptor < 1) {
+    return;
+  }
+
+  pthread_mutexattr_t mutex_attr;
+  if (pthread_mutexattr_init(&mutex_attr) != 0) {
+    goto startup_descriptor_cleanup;
+  }
+  if (pthread_mutexattr_settype(&mutex_attr, PTHREAD_MUTEX_ERRORCHECK) != 0) {
+    goto startup_descriptor_cleanup;
+  }
+  if (pthread_mutex_init(&logger_mutex, &mutex_attr) != 0) {
+    goto startup_descriptor_cleanup;
+  }
+
+  string_view_t env_var =
+      datadog_php_string_view_from_cstr("DD_PROFILING_LOG_LEVEL");
+
+  char *env = sapi_getenv_compat(env_var.ptr, env_var.len);
+  bool uses_sapi_getenv = true;
+  if (!env) {
+    uses_sapi_getenv = false;
+    env = getenv("DD_PROFILING_LOG_LEVEL");
+  }
+
+  string_view_t env_val = datadog_php_string_view_from_cstr(env);
+  log_level_t log_level = datadog_php_log_level_detect(env_val);
+
+  log_level_t corrected_log_level =
+      log_level != DATADOG_PHP_LOG_UNKNOWN ? log_level : DATADOG_PHP_LOG_OFF;
+
+  if (uses_sapi_getenv) {
+    efree(env);
+  }
+
+  if (!datadog_php_logger_ctor(&profiler_logger, descriptor,
+                               corrected_log_level, &logger_mutex)) {
+    datadog_php_logger_dtor(&profiler_logger);
+    goto cleanup_mutex;
+  }
+
+  prof_logger = (datadog_php_static_logger){
+      .log = datadog_php_log_plugin_log,
+      .logv = datadog_php_log_plugin_logv,
+      .log_cstr = datadog_php_log_plugin_log_cstr,
+  };
+  return;
+
+cleanup_mutex:
+  pthread_mutex_destroy(&logger_mutex);
+
+startup_descriptor_cleanup:
+  close(descriptor);
+}
+
+void datadog_php_log_plugin_first_activate(bool profiling_enabled) {
+  if (!profiling_enabled)
+    return;
+
+  datadog_php_log_plugin_init();
+}
+
+void datadog_php_log_plugin_shutdown(zend_extension *extension) {
+  (void)extension;
+
+  if (profiler_logger.descriptor >= 0)
+    close(profiler_logger.descriptor);
+
+  if (profiler_logger.mutex)
+    pthread_mutex_destroy(profiler_logger.mutex);
+
+  datadog_php_logger_dtor(&profiler_logger);
+}

--- a/profiling/plugins/log_plugin/log_plugin.h
+++ b/profiling/plugins/log_plugin/log_plugin.h
@@ -1,0 +1,33 @@
+#ifndef DATADOG_PHP_LOG_PLUGIN_H
+#define DATADOG_PHP_LOG_PLUGIN_H
+
+#include <Zend/zend_extensions.h>
+#include <components/log/log.h>
+#include <components/string_view/string_view.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#if __cplusplus
+#define C_STATIC(...)
+#else
+#define C_STATIC(...) static __VA_ARGS__
+#endif
+
+void datadog_php_log_plugin_first_activate(bool profiling_enabled);
+void datadog_php_log_plugin_shutdown(zend_extension *extension);
+
+/* It's called a "static logger" because the logger isn't passed as a parameter,
+ * so somewhere there must be a static object holding onto it.
+ */
+typedef struct datadog_php_static_logger_s {
+  void (*log)(datadog_php_log_level, datadog_php_string_view);
+  int64_t (*logv)(datadog_php_log_level level, size_t n_messages,
+                  datadog_php_string_view messages[C_STATIC(n_messages)]);
+  void (*log_cstr)(datadog_php_log_level log_level, const char *cstr);
+} datadog_php_static_logger;
+
+extern datadog_php_static_logger prof_logger;
+
+#undef C_STATIC
+
+#endif // DATADOG_PHP_LOG_PLUGIN_H

--- a/profiling/plugins/recorder_plugin/recorder_plugin.c
+++ b/profiling/plugins/recorder_plugin/recorder_plugin.c
@@ -1,0 +1,775 @@
+#include "recorder_plugin.h"
+
+#include <datadog-profiling.h>
+#include <php_datadog-profiling.h>
+#include <plugins/log_plugin/log_plugin.h>
+
+#include <SAPI.h>
+#include <components/arena/arena.h>
+#include <components/channel/channel.h>
+#include <components/string_view/string_view.h>
+#include <components/time/time.h>
+#include <ddprof/ffi.h>
+#include <php.h>
+#include <stdlib.h>
+#include <uv.h>
+
+// must come after php.h
+#include <ext/standard/info.h>
+
+#define SLICE_LITERAL(str)                                                     \
+  (struct ddprof_ffi_Slice_c_char) { .ptr = (str), .len = sizeof(str) - 1 }
+
+ddprof_ffi_ByteSlice to_byteslice(const char *str) {
+  return (ddprof_ffi_ByteSlice){(const uint8_t *)str, strlen(str)};
+}
+
+typedef struct string_s {
+  uint32_t len;
+  char *data;
+} string;
+
+ddprof_ffi_ByteSlice string_to_byteslice(struct string_s str) {
+  uint8_t *ptr = (uint8_t *)str.data;
+  return (ddprof_ffi_ByteSlice){.ptr = ptr, .len = str.len};
+}
+
+struct {
+  /**
+   * We need to make copies of the environment variables because they can be
+   * invalidated by the environment. We store all of these strings in the arena.
+   */
+  unsigned char strings[4096];
+  datadog_php_arena *arena;
+
+  string agent_url;
+  string env;
+  string service;
+  string version;
+  string cpu_time_enabled;
+} globals;
+
+atomic_bool datadog_php_profiling_recorder_enabled = false;
+bool datadog_php_profiling_cpu_time_enabled = false;
+
+static string arena_string_alloc(datadog_php_arena *arena, const uint32_t len) {
+  /* We ensure that every string is padded at the end by null bytes to align it
+   * to max_align_t, ensuring there is at least 1 null byte. This is would
+   * likely happen anyway if another object of the same or larger alignment is
+   * allocated next, but we guarantee it because it is useful.
+   */
+  uint32_t align = _Alignof(max_align_t);
+  uintptr_t len_with_one_null_byte = len + 1;
+  uint32_t diff = datadog_php_arena_align_diff(len_with_one_null_byte, align);
+  uint32_t allocation_size = len_with_one_null_byte + diff;
+
+  char *data = (char *)datadog_php_arena_alloc(arena, allocation_size, align);
+  if (data) {
+    // zero trailing bytes
+    memset(data + len, 0, allocation_size - len);
+    return (string){.len = allocation_size, .data = data};
+  }
+  return (string){0, ""};
+}
+
+static string arena_string_new(datadog_php_arena *arena, uint32_t len,
+                               const char *source) {
+  string dest = arena_string_alloc(arena, len);
+  if (dest.len) {
+    memcpy(dest.data, source, len);
+    dest.len = len;
+  }
+  return dest;
+}
+
+/* thread_id will point to thread_id_v if the thread is created successfully;
+ * null otherwise.
+ */
+static uv_thread_t thread_id_v, *thread_id = NULL;
+static datadog_php_channel channel;
+static ddprof_ffi_ProfileExporterV3 *exporter = NULL;
+
+typedef struct record_msg_s record_msg;
+
+/**
+ * The record_msg_s struct is what is passed over the recorder's channel.
+ * Choose the channel's capacity based on the size of this message to limit the
+ * amount of memory in the event that the channel is full.
+ */
+struct record_msg_s {
+  datadog_php_record_values record_values;
+  int64_t thread_id;
+  datadog_php_stack_sample sample;
+};
+
+_Static_assert(sizeof(record_msg) > 7168 && sizeof(record_msg) <= 8192,
+               "size of record_msg needs to nicely fit in 8KiB");
+
+/* CHANNEL_CAPACITY * sizeof(record_msg) = approx max memory used by channel
+ *              256 *              8 KiB = 2048 KiB, or 2 MiB
+ * At 1 sample per 10 milliseconds, that's 2.56 seconds worth of data that can
+ * be kept in the channel at one time.
+ */
+static const uint16_t CHANNEL_CAPACITY = UINT16_C(256);
+
+/* Currently, the recorder thread will be blocked while it is uploading a
+ * profile so it cannot pull items out of the channel. Balance the timeout with
+ * this in mind, but also realize that network requests may take a while.
+ * TODO: move uploading to another thread.
+ */
+static const uint64_t UPLOAD_TIMEOUT_MS = 10000;
+
+__attribute__((nonnull)) bool
+datadog_php_recorder_plugin_record(datadog_php_record_values record_values,
+                                   int64_t tid,
+                                   const datadog_php_stack_sample *sample) {
+  if (!datadog_php_profiling_recorder_enabled) {
+    const char *str =
+        "[Datadog Profiling] Sample dropped because profiling has been disabled.";
+    datadog_php_string_view msg = {strlen(str), str};
+    prof_logger.log(DATADOG_PHP_LOG_WARN, msg);
+    return false;
+  }
+
+  /* todo: will it be better if we hoist the record_msg allocation to the caller
+   *       and make this function only a thin, type-safe wrapper around the
+   *       channel?
+   */
+  record_msg *message = malloc(sizeof(record_msg));
+  if (message) {
+    message->record_values = record_values;
+    message->sample = *sample;
+    message->thread_id = tid;
+
+    bool success = channel.sender.send(&channel.sender, message);
+    if (!success) {
+      // todo: is this too noisy even for debug?
+      const char *str =
+          "[Datadog Profiling] Failed to store sample for aggregation; queue is likely full or closed.\n";
+      datadog_php_string_view msg = {strlen(str), str};
+      prof_logger.log(DATADOG_PHP_LOG_DEBUG, msg);
+      free(message);
+    }
+    return success;
+  }
+  return false;
+}
+
+typedef struct instant_s instant;
+struct instant_s {
+  // private:
+  uint64_t started_at_nanos;
+};
+
+static uint64_t instant_elapsed(instant self) {
+  return (uv_hrtime() - self.started_at_nanos);
+}
+
+static instant instant_now(void) {
+  instant now = {.started_at_nanos = uv_hrtime()};
+  return now;
+}
+
+static bool ddprof_ffi_export(datadog_php_static_logger *logger,
+                              const struct ddprof_ffi_Profile *profile,
+                              uint64_t timeout_ms) {
+  struct ddprof_ffi_EncodedProfile *encoded_profile =
+      ddprof_ffi_Profile_serialize(profile);
+  if (!encoded_profile) {
+    logger->log_cstr(DATADOG_PHP_LOG_WARN,
+                     "[Datadog Profiling] Failed to serialize profile.");
+    return false;
+  }
+
+  ddprof_ffi_Timespec start = encoded_profile->start;
+  ddprof_ffi_Timespec end = encoded_profile->end;
+
+  ddprof_ffi_Buffer profile_buffer = {
+      .ptr = encoded_profile->buffer.ptr,
+      .len = encoded_profile->buffer.len,
+      .capacity = encoded_profile->buffer.capacity,
+  };
+
+  ddprof_ffi_File files_[] = {{
+      .name = to_byteslice("profile.pprof"),
+      .file = &profile_buffer,
+  }};
+
+  struct ddprof_ffi_Slice_file files = {.ptr = files_,
+                                        .len = sizeof files_ / sizeof *files_};
+
+  ddprof_ffi_Request *request = ddprof_ffi_ProfileExporterV3_build(
+      exporter, start, end, files, timeout_ms);
+  bool succeeded = false;
+  if (request) {
+    struct ddprof_ffi_SendResult result =
+        ddprof_ffi_ProfileExporterV3_send(exporter, request);
+
+    if (result.tag == DDPROF_FFI_SEND_RESULT_FAILURE) {
+      datadog_php_string_view messages[2] = {
+          datadog_php_string_view_from_cstr(
+              "[Datadog Profiling] Failed to upload profile: "),
+          {result.failure.len, (const char *)result.failure.ptr},
+      };
+      logger->logv(DATADOG_PHP_LOG_WARN, 2, messages);
+    } else if (result.tag == DDPROF_FFI_SEND_RESULT_HTTP_RESPONSE) {
+      uint16_t code = result.http_response.code;
+      if (200 <= code && code < 300) {
+        logger->log_cstr(DATADOG_PHP_LOG_INFO,
+                         "[Datadog Profiling] Successfully uploaded profile.");
+        succeeded = true;
+      } else {
+        char code_string[8] = {'u', 'n', 'k', 'n', 'o', 'w', 'n', '\0'};
+        (void)snprintf(code_string, sizeof code_string, "%" PRIu16, code);
+        datadog_php_string_view messages[2] = {
+            datadog_php_string_view_from_cstr(
+                "[Datadog Profiling] Unexpected HTTP status code when sending profile: "),
+            {strlen(code_string), code_string},
+        };
+        datadog_php_log_level log_level =
+            code >= 400 ? DATADOG_PHP_LOG_ERROR : DATADOG_PHP_LOG_WARN;
+        logger->logv(log_level, 2, messages);
+      }
+    }
+  } else {
+    logger->log_cstr(DATADOG_PHP_LOG_WARN,
+                     "[Datadog Profiling] Failed to create HTTP request.");
+  }
+  ddprof_ffi_EncodedProfile_delete(encoded_profile);
+  return succeeded;
+}
+
+/**
+ * A frame is empty if it has neither a file name nor a function name.
+ */
+static bool is_empty_frame(datadog_php_stack_sample_frame *frame) {
+  return (frame->function.len | frame->file.len) == 0;
+}
+
+static void datadog_php_recorder_add(struct ddprof_ffi_Profile *profile,
+                                     record_msg *message) {
+  uint32_t locations_capacity = message->sample.depth;
+  struct ddprof_ffi_Location *locations =
+      calloc(locations_capacity, sizeof(struct ddprof_ffi_Location));
+  if (!locations) {
+    prof_logger.log_cstr(
+        DATADOG_PHP_LOG_WARN,
+        "[Datadog Profiling] Failed to allocate storage for sample locations.");
+    return;
+  }
+
+  // There is one line per location, at least as long as PHP doesn't inline
+  struct ddprof_ffi_Line *lines =
+      calloc(locations_capacity, sizeof(struct ddprof_ffi_Line));
+  if (!lines) {
+    prof_logger.log_cstr(
+        DATADOG_PHP_LOG_WARN,
+        "[Datadog Profiling] Failed to allocate storage for sample lines.");
+    goto free_locations;
+  }
+
+  uint16_t locations_size = 0;
+  datadog_php_stack_sample_iterator iterator;
+  for (iterator = datadog_php_stack_sample_iterator_ctor(&message->sample);
+       datadog_php_stack_sample_iterator_valid(&iterator);
+       datadog_php_stack_sample_iterator_next(&iterator)) {
+    datadog_php_stack_sample_frame frame =
+        datadog_php_stack_sample_iterator_frame(&iterator);
+
+    if (is_empty_frame(&frame)) {
+      continue;
+    }
+
+    struct ddprof_ffi_Line *line = lines + locations_size;
+    struct ddprof_ffi_Function function = {
+        .name = {.ptr = frame.function.ptr, .len = frame.function.len},
+        .filename = {.ptr = frame.file.ptr, .len = frame.file.len},
+    };
+    line->function = function;
+    line->line = frame.lineno;
+
+    struct ddprof_ffi_Location location = {
+        /* Yes, we use an empty mapping! We don't map to a .so or anything
+         * remotely like it, so we do not pretend.
+         */
+        .mapping = {},
+        .lines = {.ptr = line, .len = 1},
+        .is_folded = false,
+    };
+    locations[locations_size++] = location;
+  }
+  datadog_php_stack_sample_iterator_dtor(&iterator);
+
+  int64_t values_storage[3] = {
+      (int64_t)message->record_values.count,
+      message->record_values.wall_time,
+      message->record_values.cpu_time,
+  };
+  size_t values_storage_len = datadog_php_profiling_cpu_time_enabled ? 3 : 2;
+  struct ddprof_ffi_Slice_i64 values = {.ptr = values_storage,
+                                        .len = values_storage_len};
+
+  char thread_id_str[24];
+  size_t thread_id_len;
+  int result = snprintf(thread_id_str, sizeof thread_id_str, "%" PRId64,
+                        message->thread_id);
+  if (result <= 0 || ((size_t)result) >= sizeof thread_id_str) {
+    // include null byte in copy
+    thread_id_len = sizeof("{unknown thread id}") - 1;
+    memcpy(thread_id_str, "{unknown thread id}", thread_id_len + 1);
+  } else {
+    thread_id_len = result;
+  }
+  ddprof_ffi_Label thread_id_label = {
+      .key = {"thread id", sizeof("thread id") - 1},
+      .str = {thread_id_str, thread_id_len},
+  };
+  struct ddprof_ffi_Sample sample = {
+      .values = values,
+      .locations = {.ptr = locations, .len = locations_size},
+      .labels = {.ptr = &thread_id_label, .len = 1},
+  };
+
+  ddprof_ffi_Profile_add(profile, sample);
+
+  free(lines);
+free_locations:
+  free(locations);
+}
+
+static const struct ddprof_ffi_Period period = {
+    .type_ =
+        {
+            .type_ = SLICE_LITERAL("wall-time"),
+            .unit = SLICE_LITERAL("nanoseconds"),
+        },
+
+    /* An interval of 60 seconds often ends up with an HTTP 502 Bad Gateway
+     * every 2nd request. I have not investigated this, but I suspect that it
+     * has to do with some timeout set to 60 seconds and hasn't healed yet.
+     *
+     * This only occurs when going through the agent, not directly to intake.
+     *
+     * So, I did the sensible thing of picking a prime number close to 60
+     * seconds. The choices 59 and 61 seems like they might be _too_ close, so
+     * I went with 67 seconds.
+     */
+    .value = 67000000000,
+};
+
+static struct ddprof_ffi_Profile *profile_new(void) {
+
+  /* Some tools assume the last value type is the "primary" one, so put
+   * cpu-time last, as that's what the Datadog UI will default to (once it is
+   * released).
+   */
+  static struct ddprof_ffi_ValueType value_types[3] = {
+      {
+          .type_ = SLICE_LITERAL("sample"),
+          .unit = SLICE_LITERAL("count"),
+      },
+      {
+          .type_ = SLICE_LITERAL("wall-time"),
+          .unit = SLICE_LITERAL("nanoseconds"),
+      },
+      {
+          .type_ = SLICE_LITERAL("cpu-time"),
+          .unit = SLICE_LITERAL("nanoseconds"),
+      },
+  };
+
+  /* Note that the maximum memory used by the profile can be estimated with
+   * decent accuracy by using the period, sample frequency, maximum payload size
+   * of each sample, and the channel's capacity.
+   * HOWEVER, this may not hold true for future profiles, such as garbage
+   * collection profiling, so be cautious about that when adding them.
+   */
+  struct ddprof_ffi_Slice_value_type sample_types = {
+      .ptr = value_types,
+      .len = datadog_php_profiling_cpu_time_enabled ? 3 : 2,
+  };
+  return ddprof_ffi_Profile_new(sample_types, &period);
+}
+
+void datadog_php_recorder_plugin_main(void) {
+  if (period.value < 0) {
+    // widest i64 is -9223372036854775808 (20 chars)
+    char buffer[24] = {'(', 'u', 'n', 'k', 'n', 'o', 'w', 'n', ')', '\0'};
+
+    (void)snprintf(buffer, sizeof buffer, "%" PRId64, period.value);
+
+    datadog_php_string_view messages[] = {
+        datadog_php_string_view_from_cstr(
+            "[Datadog Profiling] Failed to start; invalid upload period of "),
+        {strlen(buffer), buffer},
+        datadog_php_string_view_from_cstr("."),
+    };
+    size_t n_messages = sizeof messages / sizeof *messages;
+    prof_logger.logv(DATADOG_PHP_LOG_ERROR, n_messages, messages);
+    return;
+  }
+
+  const uint64_t period_val = (uint64_t)period.value;
+  datadog_php_receiver *receiver = &channel.receiver;
+  struct ddprof_ffi_Profile *profile = profile_new();
+  if (!profile) {
+    const char *msg =
+        "[Datadog Profiling] Failed to create profile. Samples will not be collected.";
+    prof_logger.log_cstr(DATADOG_PHP_LOG_ERROR, msg);
+    return;
+  } else {
+    const char *msg = "[Datadog Profiling] Recorder online.";
+    prof_logger.log_cstr(DATADOG_PHP_LOG_DEBUG, msg);
+  }
+
+  while (datadog_php_profiling_recorder_enabled) {
+    uint64_t sleep_for_nanos = period_val;
+    instant before = instant_now();
+    do {
+      record_msg *message;
+      if (receiver->recv(receiver, (void **)&message, sleep_for_nanos)) {
+        // an empty message can be sent, such as when we're shutting down
+        if (message) {
+          datadog_php_recorder_add(profile, message);
+          free(message);
+        }
+      }
+      uint64_t duration = instant_elapsed(before);
+      sleep_for_nanos = duration < period_val ? period_val - duration : 0;
+      // protect against underflow
+    } while (datadog_php_profiling_recorder_enabled && sleep_for_nanos);
+
+    ddprof_ffi_export(&prof_logger, profile, UPLOAD_TIMEOUT_MS);
+    (void)ddprof_ffi_Profile_reset(profile);
+  }
+
+  ddprof_ffi_Profile_free(profile);
+  receiver->dtor(receiver);
+}
+
+void datadog_php_recorder_plugin_shutdown(zend_extension *extension) {
+  (void)extension;
+
+  if (!datadog_php_profiling_recorder_enabled)
+    return;
+
+  datadog_php_arena_delete(globals.arena);
+
+  // Disable the plugin before sending as that flag's checked by the receiver.
+  datadog_php_profiling_recorder_enabled = false;
+
+  // Send an empty message to wake receiver up.
+  channel.sender.send(&channel.sender, NULL);
+
+  // Must clean up channel sender before thread join, or it will deadlock.
+  channel.sender.dtor(&channel.sender);
+
+  if (thread_id && uv_thread_join(thread_id)) {
+    const char *str = "[Datadog Profiling] Recorder thread failed to join.";
+    datadog_php_string_view message = {strlen(str), str};
+    prof_logger.log(DATADOG_PHP_LOG_WARN, message);
+  } else {
+    const char *str = "[Datadog Profiling] Recorder offline.";
+    datadog_php_string_view message = {strlen(str), str};
+    prof_logger.log(DATADOG_PHP_LOG_INFO, message);
+  }
+
+  ddprof_ffi_ProfileExporterV3_delete(exporter);
+}
+
+// todo: extract this to sensible location (not recorder)
+// Adapted from zai_env from Tracer project {{{
+#if PHP_VERSION_ID >= 80000
+#define sapi_getenv_compat(name, name_len) sapi_getenv((name), name_len)
+#elif PHP_VERSION_ID >= 70000
+#define sapi_getenv_compat(name, name_len) sapi_getenv((char *)(name), name_len)
+#else
+#define sapi_getenv_compat(name, name_len)                                     \
+  sapi_getenv((char *)(name), name_len TSRMLS_CC)
+#endif
+
+/**
+ * Only call during .first_activate.
+ */
+static string datadog_php_profiler_getenv(datadog_php_string_view name,
+                                          datadog_php_arena *arena) {
+  if (!name.len || !name.ptr || !arena)
+    return (string){.len = 0, .data = ""};
+
+  /* Some SAPIs do not initialize the SAPI-controlled environment variables
+   * until SAPI RINIT. It is for this reason we cannot reliably access
+   * environment variables until module RINIT.
+   */
+  if (!PG(modules_activated) && !PG(during_request_startup))
+    return (string){.len = 0, .data = ""};
+
+  /* sapi_getenv may or may not include process environment variables.
+   * It will return NULL when it is not found in the possibly synthetic SAPI
+   * environment. Hence, we need to do a getenv() in any case.
+   */
+  bool use_sapi_env = false;
+
+  char *value = sapi_getenv_compat(name.ptr, name.len);
+  if (value) {
+    use_sapi_env = true;
+  } else {
+    value = getenv(name.ptr);
+  }
+
+  if (!value)
+    return (string){.len = 0, .data = ""};
+
+  size_t value_len = strlen(value);
+
+  string result = arena_string_new(arena, value_len, value);
+
+  if (use_sapi_env)
+    efree(value);
+
+  return result;
+}
+// }}}
+
+#define SV(literal)                                                            \
+  (datadog_php_string_view) { sizeof(literal) - 1, literal }
+
+static string datadog_php_profiler_getenv_or(datadog_php_string_view name,
+                                             datadog_php_arena *arena,
+                                             datadog_php_string_view default_) {
+  string env_var = datadog_php_profiler_getenv(name, arena);
+  if (!env_var.len || !env_var.data[0]) {
+    // the env_var doesn't have any data -- use the default instead
+    return arena_string_new(arena, default_.len, default_.ptr);
+  }
+  return env_var;
+}
+
+static bool recorder_first_activate_helper() {
+  globals.arena =
+      datadog_php_arena_new(sizeof globals.strings, globals.strings);
+  bool success = globals.arena != NULL;
+
+  if (success) {
+    success = datadog_php_channel_ctor(&channel, CHANNEL_CAPACITY);
+  }
+
+  if (!success) {
+    datadog_php_arena_delete(globals.arena);
+    return false;
+  }
+
+  // todo: DD_SITE + DD_API_KEY
+  const char *path = "/profiling/v1/input";
+  datadog_php_arena *arena = globals.arena;
+
+  // prioritize URL over HOST + PORT
+  string url = datadog_php_profiler_getenv(SV("DD_TRACE_AGENT_URL"), arena);
+  if (!url.len || !url.data[0]) {
+
+    string env_host = datadog_php_profiler_getenv(SV("DD_AGENT_HOST"), arena);
+    const char *host =
+        env_host.len && env_host.data[0] ? env_host.data : "localhost";
+
+    string env_port =
+        datadog_php_profiler_getenv(SV("DD_TRACE_AGENT_PORT"), arena);
+    const char *port =
+        env_port.len && env_port.data[0] ? env_port.data : "8126";
+
+    // todo: can I log here?
+    int size = snprintf(NULL, 0, "http://%s:%s%s", host, port, path);
+    if (size <= 0)
+      return false;
+
+    string buffer = arena_string_alloc(arena, size);
+    if (!buffer.len) {
+      const char *msg =
+          "[Datadog Profiling] Failed to start; could not create memory arena for configuration settings.";
+      prof_logger.log_cstr(DATADOG_PHP_LOG_ERROR, msg);
+      return false;
+    }
+
+    int result =
+        snprintf(buffer.data, buffer.len, "http://%s:%s%s", host, port, path);
+    if (result < size) {
+      // todo: log failure
+      return false;
+    }
+
+    globals.agent_url = buffer;
+  } else {
+    globals.agent_url = url;
+  }
+
+  // empty string is permitted for service
+  datadog_php_string_view empty = {0, ""};
+  globals.service =
+      datadog_php_profiler_getenv_or(SV("DD_SERVICE"), arena, empty);
+
+  // empty string is permitted for service
+  globals.version =
+      datadog_php_profiler_getenv_or(SV("DD_VERSION"), arena, empty);
+
+  // empty string is permitted for env
+  globals.env = datadog_php_profiler_getenv_or(SV("DD_ENV"), arena, empty);
+
+  // experimental: enable cpu-time profile
+  datadog_php_string_view no = {2, "no"};
+  globals.cpu_time_enabled = datadog_php_profiler_getenv_or(
+      SV("DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED"), arena, no);
+
+  datadog_php_profiling_cpu_time_enabled =
+      datadog_php_string_view_is_boolean_true(
+          (datadog_php_string_view){.len = globals.cpu_time_enabled.len,
+                                    .ptr = globals.cpu_time_enabled.data});
+
+  ddprof_ffi_ByteSlice base_url = string_to_byteslice(globals.agent_url);
+  ddprof_ffi_EndpointV3 endpoint = ddprof_ffi_EndpointV3_agent(base_url);
+
+  ddprof_ffi_Tag tags_[] = {
+      {.name = to_byteslice("language"), .value = to_byteslice("php")},
+      {.name = to_byteslice("service"),
+       .value = string_to_byteslice(globals.service)},
+      {.name = to_byteslice("env"), .value = string_to_byteslice(globals.env)},
+      {.name = to_byteslice("version"),
+       .value = string_to_byteslice(globals.version)},
+      {.name = to_byteslice("profiler_version"),
+       .value = to_byteslice(PHP_DATADOG_PROFILING_VERSION)},
+  };
+
+  ddprof_ffi_Slice_tag tags = {.ptr = tags_,
+                               .len = sizeof tags_ / sizeof *tags_};
+
+  struct ddprof_ffi_NewProfileExporterV3Result exporter_result =
+      ddprof_ffi_ProfileExporterV3_new(to_byteslice("php"), tags, endpoint);
+  if (exporter_result.tag == DDPROF_FFI_NEW_PROFILE_EXPORTER_V3_RESULT_ERR) {
+    const char *str =
+        "[Datadog Profiling] Failed to start; could not create HTTP uploader: ";
+    datadog_php_string_view messages[] = {
+        {strlen(str), str},
+        {exporter_result.err.len, (const char *)exporter_result.err.ptr},
+    };
+    prof_logger.logv(DATADOG_PHP_LOG_ERROR, sizeof messages / sizeof *messages,
+                     messages);
+    ddprof_ffi_NewProfileExporterV3Result_dtor(exporter_result);
+    return false;
+  }
+
+  exporter = exporter_result.ok;
+
+  thread_id = &thread_id_v;
+  int result = uv_thread_create(
+      thread_id, (uv_thread_cb)datadog_php_recorder_plugin_main, NULL);
+  if (result != 0) {
+    thread_id = NULL;
+    ddprof_ffi_ProfileExporterV3_delete(exporter);
+    channel.receiver.dtor(&channel.receiver);
+    channel.sender.dtor(&channel.sender);
+
+    const char *str =
+        "[Datadog Profiling] Failed to start; could not create thread for aggregating profiles.";
+    datadog_php_string_view msg = {strlen(str), str};
+    prof_logger.log(DATADOG_PHP_LOG_ERROR, msg);
+    return false;
+  }
+  return true;
+}
+
+void datadog_php_recorder_plugin_first_activate(bool profiling_enabled) {
+  datadog_php_profiling_recorder_enabled =
+      profiling_enabled && recorder_first_activate_helper();
+}
+
+#if __cplusplus
+#define C_STATIC(...)
+#else
+#define C_STATIC(...) static __VA_ARGS__
+#endif
+
+static int64_t
+upload_logv(datadog_php_log_level level, size_t n_messages,
+            datadog_php_string_view messages[C_STATIC(n_messages)]) {
+
+  const char *key;
+  switch (level) {
+  default:
+  case DATADOG_PHP_LOG_UNKNOWN:
+    key = "unknown"; // shouldn't happen at this location
+    break;
+  case DATADOG_PHP_LOG_OFF:
+    key = "off"; // shouldn't happen at this location
+    break;
+  case DATADOG_PHP_LOG_ERROR:
+    key = "error";
+    break;
+  case DATADOG_PHP_LOG_WARN:
+    key = "warn";
+    break;
+  case DATADOG_PHP_LOG_INFO:
+    key = "info";
+    break;
+  case DATADOG_PHP_LOG_DEBUG:
+    key = "debug";
+    break;
+  }
+
+  size_t bytes = 2; // trailing newline and null byte
+  for (size_t i = 0; i != n_messages; ++i) {
+    bytes += messages[i].len;
+  }
+
+  char *message = malloc(bytes);
+  if (message) {
+    size_t offset = 0;
+    for (size_t i = 0; i != n_messages; ++i) {
+      memcpy(message + offset, messages[i].ptr, messages[i].len);
+      offset += messages[i].len;
+    }
+    message[offset] = '\n';
+    message[offset + 1] = '\0';
+  }
+
+  datadog_profiling_info_diagnostics_row(
+      key, message ? message : "(error formatting messages)\n");
+
+  free(message);
+
+  return 0; // not intended to be checked
+}
+
+static void upload_log(datadog_php_log_level level,
+                       datadog_php_string_view message) {
+  (void)upload_logv(level, 1, &message);
+}
+
+static void upload_log_cstr(datadog_php_log_level level, const char *cstr) {
+  upload_log(level, datadog_php_string_view_from_cstr(cstr));
+}
+
+#undef C_STATIC
+
+void datadog_php_recorder_plugin_diagnose(void) {
+  const char *yes = "yes", *no = "no";
+
+  php_info_print_table_colspan_header(2, "Profiling Recorder Diagnostics");
+
+  datadog_profiling_info_diagnostics_row(
+      "Enabled", datadog_php_profiling_recorder_enabled ? yes : no);
+
+  struct ddprof_ffi_Profile *profile = profile_new();
+  datadog_profiling_info_diagnostics_row("Can create profiles",
+                                         profile ? yes : no);
+  if (datadog_php_profiling_recorder_enabled && profile) {
+    datadog_php_static_logger logger = {
+        .log = upload_log,
+        .logv = upload_logv,
+        .log_cstr = upload_log_cstr,
+    };
+
+    php_info_print_table_colspan_header(2, "Profiling Upload Diagnostics");
+    bool uploaded = ddprof_ffi_export(&logger, profile, UPLOAD_TIMEOUT_MS);
+    datadog_profiling_info_diagnostics_row("Can upload profiles",
+                                           uploaded ? yes : no);
+  }
+
+  ddprof_ffi_Profile_free(profile);
+}

--- a/profiling/plugins/recorder_plugin/recorder_plugin.h
+++ b/profiling/plugins/recorder_plugin/recorder_plugin.h
@@ -1,0 +1,34 @@
+#ifndef DATADOG_PHP_RECORDER_PLUGIN_H
+#define DATADOG_PHP_RECORDER_PLUGIN_H
+
+#include <Zend/zend_extensions.h>
+#include <stack-collector/stack-collector.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+extern atomic_bool datadog_php_profiling_recorder_enabled;
+extern bool datadog_php_profiling_cpu_time_enabled;
+
+/* The recorder has two high level responsibilities:
+ *  1. Aggregate samples.
+ *  2. Export profiles once the configured period has elapsed.
+ */
+
+typedef struct datadog_php_record_values {
+  uint64_t count;    // usually 0 or 1
+  int64_t wall_time; // wall time in ns since last sample, may be 0
+  int64_t cpu_time;  // cpu time in ns since last sample, may be 0
+} datadog_php_record_values;
+
+__attribute__((nonnull)) bool
+datadog_php_recorder_plugin_record(datadog_php_record_values record_values,
+                                   int64_t tid,
+                                   const datadog_php_stack_sample *sample);
+
+void datadog_php_recorder_plugin_first_activate(bool profiling_enabled);
+void datadog_php_recorder_plugin_shutdown(zend_extension *extension);
+
+void datadog_php_recorder_plugin_diagnose(void);
+
+#endif // DATADOG_PHP_RECORDER_PLUGIN_H

--- a/profiling/plugins/stack_collector_plugin/stack_collector_plugin.c
+++ b/profiling/plugins/stack_collector_plugin/stack_collector_plugin.c
@@ -1,0 +1,382 @@
+#include "stack_collector_plugin.h"
+
+#include "../log_plugin/log_plugin.h"
+#include "../recorder_plugin/recorder_plugin.h"
+#include <components/time/time.h>
+#include <stack-collector/stack-collector.h>
+
+#include <Zend/zend_execute.h>
+#include <errno.h>
+#include <php_config.h>
+#include <stdatomic.h>
+#include <uv.h>
+
+typedef datadog_php_stack_sample stack_sample_t;
+typedef datadog_php_stack_sample_frame stack_sample_frame_t;
+typedef datadog_php_stack_sample_iterator stack_sample_iterator_t;
+
+struct globals_s {
+  bool have_thread;
+  pthread_t thread;
+
+  void (*prev_interrupt_function)(zend_execute_data *);
+  void (*prev_execute_internal)(zend_execute_data *, zval *);
+};
+
+static struct globals_s globals;
+
+ZEND_TLS int64_t zend_thread_id;
+static _Atomic bool enabled;
+
+void datadog_php_stack_collector_first_activate(bool profiling_enabled) {
+  zend_thread_id = (int64_t)uv_thread_self();
+
+  if (datadog_php_profiling_cpu_time_enabled) {
+    datadog_php_cpu_time_result now = datadog_php_cpu_time_now();
+    if (now.tag == DATADOG_PHP_CPU_TIME_ERR) {
+      datadog_php_string_view messages[] = {
+          datadog_php_string_view_from_cstr(
+              "[Datadog Profiling] Failed to retrieve cpu time; profiles will not be collected: "),
+          datadog_php_string_view_from_cstr(now.err),
+      };
+      prof_logger.logv(DATADOG_PHP_LOG_ERROR,
+                       sizeof messages / sizeof *messages, messages);
+      enabled = false;
+      return;
+    }
+  }
+
+  enabled = profiling_enabled;
+}
+
+/* By default, no interrupt function is set. Other extensions may set one, and
+ * if so then it ought to be called when overriding it. The _helper version
+ * will call the previous interrupt function.
+ */
+static void datadog_php_stack_collector_interrupt_function(zend_execute_data *);
+static void
+datadog_php_stack_collector_interrupt_function_helper(zend_execute_data *);
+
+/* previous execute_internal function _must not_ be null; set to
+ * execute_internal if necessary
+ */
+static void datadog_php_stack_collector_execute_internal(zend_execute_data *,
+                                                         zval *retval);
+
+void datadog_php_stack_collector_startup(zend_extension *extension) {
+  (void)extension;
+
+#if !defined(ZTS)
+  globals.prev_interrupt_function = zend_interrupt_function;
+  zend_interrupt_function = globals.prev_interrupt_function
+      ? datadog_php_stack_collector_interrupt_function_helper
+      : datadog_php_stack_collector_interrupt_function;
+
+  globals.prev_execute_internal =
+      zend_execute_internal ? zend_execute_internal : execute_internal;
+  zend_execute_internal = datadog_php_stack_collector_execute_internal;
+#endif
+}
+
+typedef uint64_t uv_hrtime_t;
+
+/**
+ * We need to pass the address of the VM interrupt (or the whole globals) to the
+ * interrupt function. We also need to pass our own interrupt flag, as other
+ * extensions can trigger interrupts as well, and we should only handle our own.
+ *
+ * The sigevent struct can only pass an integer or a single pointer, so we make
+ * a composite struct to hold everything we need.
+ */
+typedef struct stack_collector_thread_globals {
+  _Atomic uint32_t interrupt_count;
+  zend_executor_globals *eg;
+  bool have_uv_loop;
+  uv_loop_t uv_loop;
+  uv_timer_t uv_timer;
+  uv_async_t stop_async;
+  uv_hrtime_t last_event_at;
+  struct timespec last_cpu;
+  stack_sample_t sample; // this is big!
+} stack_collector_thread_globals;
+
+_Thread_local stack_collector_thread_globals thread_globals;
+
+void datadog_php_stack_collector_deactivate(void) {
+  if (!enabled)
+    return;
+
+  if (thread_globals.have_uv_loop) {
+    // return code is not documented; quick scan of src on unix only returns 0
+    (void)uv_async_send(&thread_globals.stop_async);
+  }
+
+  if (globals.have_thread) {
+    enum {
+      PTHREAD_JOIN_SUCCESS = 0,
+      PTHREAD_JOIN_EDEADLK = EDEADLK,
+      PTHREAD_JOIN_EINVAL = EINVAL,
+      PTHREAD_JOIN_ESRCH = ESRCH,
+
+    } status = pthread_join(globals.thread, NULL);
+
+    if (status != PTHREAD_JOIN_SUCCESS) {
+      datadog_php_log_level level = DATADOG_PHP_LOG_ERROR;
+      datadog_php_string_view messages[2] = {
+          datadog_php_string_view_from_cstr(
+              "[Datadog Profiling] Stack Collector failed to join: "),
+          datadog_php_string_view_from_cstr(strerror(status)),
+      };
+
+      prof_logger.logv(level, 2, messages);
+    }
+  }
+
+  globals.have_thread = false;
+}
+
+static void datadog_php_stack_collector_collect_cb(uv_timer_t *handle) {
+  stack_collector_thread_globals *remote_globals = handle->data;
+
+  /* There is a race condition here; the VM could handle the interrupt after
+   * the counter has been incremented but before the global vm_interrupt has
+   * been set.
+   * Mostly, this means that sometimes the vm_interrupt will have an extra
+   * count, or sometimes it will run and be 0. Both situations should be
+   * tolerable.
+   */
+  uint32_t prev_val = atomic_fetch_add(&remote_globals->interrupt_count, 1);
+  if (prev_val == 0) {
+    remote_globals->eg->vm_interrupt = 1;
+  }
+}
+
+void stop_uv_async_cb(uv_async_t *handle) {
+  stack_collector_thread_globals *remote_globals = handle->data;
+  uv_stop(handle->loop);
+  uv_close((uv_handle_t *)&remote_globals->uv_timer, NULL);
+  uv_close((uv_handle_t *)&remote_globals->stop_async, NULL);
+  remote_globals->have_uv_loop = false;
+}
+
+static void libuv_close_handles(uv_handle_t *handle, void *arg) {
+  (void)arg;
+  uv_close(handle, NULL);
+}
+
+static void *datadog_php_stack_collector_loop(
+    stack_collector_thread_globals *remote_globals) {
+  prof_logger.log_cstr(DATADOG_PHP_LOG_DEBUG,
+                       "[Datadog Profiling] Stack Collector online.");
+
+  uv_loop_t *loop = &remote_globals->uv_loop;
+
+  // If there are unclosed handles this will return non-zero
+  if (uv_run(loop, UV_RUN_DEFAULT)) {
+    // make an attempt to close all handles
+    uv_walk_cb walk_cb = libuv_close_handles;
+    uv_walk(loop, walk_cb, NULL);
+
+    // run it once to allow libuv to call the close handlers
+    (void)uv_run(loop, UV_RUN_NOWAIT);
+  }
+
+  // if there are open handles this will return UV_EBUSY
+  if (uv_loop_close(loop)) {
+    char *cstr =
+        "[Datadog Profiling] Stack Collector uncleanly exited; memory leaks are likely.";
+    prof_logger.log_cstr(DATADOG_PHP_LOG_WARN, cstr);
+  } else {
+    prof_logger.log_cstr(DATADOG_PHP_LOG_DEBUG,
+                         "[Datadog Profiling] Stack Collector cleanly exited.");
+  }
+
+  return NULL;
+}
+
+static bool libuv_activate(stack_collector_thread_globals *remote_globals) {
+  uv_loop_t *loop = &remote_globals->uv_loop;
+  if (uv_loop_init(loop) != 0) {
+    const char *msg =
+        "[Datadog Profiling] Stack Collector uv_loop_init returned non-zero status";
+    prof_logger.log_cstr(DATADOG_PHP_LOG_ERROR, msg);
+    return false;
+  }
+
+  uv_timer_t *timer = &remote_globals->uv_timer;
+  if (uv_timer_init(loop, timer)) {
+    const char *msg =
+        "[Datadog Profiling] Stack Collector uv_timer_init returned non-zero status.";
+    prof_logger.log_cstr(DATADOG_PHP_LOG_ERROR, msg);
+    goto cleanup_loop;
+  }
+
+  timer->data = remote_globals;
+
+  // timeout and repeat are in milliseconds.
+  uv_timer_cb cb = datadog_php_stack_collector_collect_cb;
+  if (uv_timer_start(timer, cb, 10, 10) != 0) {
+    const char *msg =
+        "[Datadog Profiling] Stack Collector uv_timer_start returned non-zero status.";
+    prof_logger.log_cstr(DATADOG_PHP_LOG_ERROR, msg);
+    goto cleanup_timer;
+  }
+
+  uv_async_t *stop_async = &remote_globals->stop_async;
+  stop_async->data = remote_globals;
+  if (uv_async_init(loop, stop_async, stop_uv_async_cb) != 0) {
+    const char *msg =
+        "[Datadog Profiling] Stack Collector uv_async_init  returned non-zero status.";
+    prof_logger.log_cstr(DATADOG_PHP_LOG_ERROR, msg);
+    goto cleanup_timer;
+  }
+
+  return true;
+
+cleanup_timer:
+  uv_timer_stop(timer);
+
+cleanup_loop:
+  uv_loop_close(loop);
+  return false;
+}
+
+void datadog_php_stack_collector_activate(void) {
+  if (!enabled)
+    return;
+
+  atomic_store(&thread_globals.interrupt_count, 0);
+  thread_globals.eg = &executor_globals;
+  thread_globals.have_uv_loop = false;
+  thread_globals.last_event_at = uv_hrtime();
+
+  struct timespec cpu_spec = {};
+  if (datadog_php_profiling_cpu_time_enabled) {
+    datadog_php_cpu_time_result cpu_now = datadog_php_cpu_time_now();
+    if (cpu_now.tag == DATADOG_PHP_CPU_TIME_OK) {
+      cpu_spec = cpu_now.ok;
+    }
+  }
+  thread_globals.last_cpu = cpu_spec;
+
+  datadog_php_stack_sample_ctor(&thread_globals.sample);
+
+  thread_globals.have_uv_loop = libuv_activate(&thread_globals);
+  if (!thread_globals.have_uv_loop) {
+    return;
+  }
+
+  enum {
+    PTHREAD_CREATE_SUCCESS = 0,
+    PTHREAD_CREATE_EAGAIN = EAGAIN,
+    PTHREAD_CREATE_EINVAL = EINVAL,
+    PTHREAD_CREATE_EPERM = EPERM,
+  } status = pthread_create(&globals.thread, NULL,
+                            (void *(*)(void *))datadog_php_stack_collector_loop,
+                            &thread_globals);
+
+  if (status != PTHREAD_CREATE_SUCCESS) {
+    const char *str = NULL;
+    switch (status) {
+    case PTHREAD_CREATE_EAGAIN:
+      str = "[Datadog Profiling] Error creating pthread; EAGAIN.";
+      break;
+
+    case PTHREAD_CREATE_EINVAL:
+      str = "[Datadog Profiling] Error creating pthread; EINVAL.";
+      break;
+
+    case PTHREAD_CREATE_EPERM:
+      str = "[Datadog Profiling] Error creating pthread; EPERM.";
+      break;
+
+    default:
+      str = "[Datadog Profiling] Error creating pthread; unknown error.";
+    }
+    prof_logger.log_cstr(DATADOG_PHP_LOG_ERROR, str);
+    return;
+  }
+
+  globals.have_thread = true;
+}
+
+static void datadog_php_stack_collector_interrupt_function(
+    zend_execute_data *execute_data) {
+  if (!enabled || !datadog_php_profiling_recorder_enabled) {
+    return;
+  }
+
+  uint32_t interrupt_count =
+      atomic_exchange(&thread_globals.interrupt_count, 0);
+
+  /* This may be 0 due to legitimate cases. Our zend_execute_internal override
+   * may call this function and then the engine may call it again when it does
+   * its regular VM interrupt afterwards, and this may be 0 in such cases.
+   * It may also be 0 if another extension triggered the interrupt.
+   * Therefore, don't consider interrupt_count == 0 to be a defect.
+   */
+  if (interrupt_count == 0) {
+    return;
+  }
+
+  uv_hrtime_t last_event_at = thread_globals.last_event_at;
+  thread_globals.last_event_at = uv_hrtime();
+
+  int64_t cpu_time = 0;
+  if (datadog_php_profiling_cpu_time_enabled) {
+    datadog_php_cpu_time_result cpu_now = datadog_php_cpu_time_now();
+    if (cpu_now.tag == DATADOG_PHP_CPU_TIME_OK) {
+      struct timespec now = cpu_now.ok;
+      struct timespec then = thread_globals.last_cpu;
+      int64_t current = now.tv_sec * INT64_C(1000000000) + now.tv_nsec;
+      int64_t prev = then.tv_sec * INT64_C(1000000000) + then.tv_nsec;
+      cpu_time = current - prev;
+      thread_globals.last_cpu = now;
+    }
+  }
+
+  datadog_php_stack_collect(execute_data, &thread_globals.sample);
+  if (!thread_globals.sample.depth) {
+    return;
+  }
+
+  uv_hrtime_t ns_since_last = thread_globals.last_event_at - last_event_at;
+  datadog_php_record_values values = {
+      .count = (int64_t)interrupt_count,
+      .wall_time = (int64_t)ns_since_last,
+      .cpu_time = cpu_time,
+  };
+
+  datadog_php_recorder_plugin_record(values, zend_thread_id,
+                                     &thread_globals.sample);
+}
+
+static void datadog_php_stack_collector_interrupt_function_helper(
+    zend_execute_data *execute_data) {
+  datadog_php_stack_collector_interrupt_function(execute_data);
+  globals.prev_interrupt_function(execute_data);
+}
+
+/* The purpose of this hook is to be able to handle interrupts _before_ the
+ * engine pops the internal call frame off the top of the stack. This has extra
+ * performance cost.
+ * Ideally we'd get a patch into upstream PHP to adjust precisely when the
+ * interrupt handling occurs, so we can catch internal funcs, but the current
+ * model relies on interrupts happening only at the end of opcodes so that
+ * an interrupt can cause the engine to jump to another place. This could be
+ * used to implement coroutine scheduling, for example. Since internal function
+ * calls are a single opcode, we cannot trigger the interrupt before cleaning up
+ * and preserve this semantic.
+ */
+static void
+datadog_php_stack_collector_execute_internal(zend_execute_data *execute_data,
+                                             zval *retval) {
+  globals.prev_execute_internal(execute_data, retval);
+  if (UNEXPECTED(EG(vm_interrupt))) {
+    /* This calls the version that doesn't delegate to the previous interrupt
+     * function since interrupt handlers are not designed to run at this
+     * location of the VM.
+     */
+    datadog_php_stack_collector_interrupt_function(execute_data);
+  }
+}

--- a/profiling/plugins/stack_collector_plugin/stack_collector_plugin.h
+++ b/profiling/plugins/stack_collector_plugin/stack_collector_plugin.h
@@ -1,0 +1,12 @@
+#ifndef DATADOG_PHP_STACK_COLLECTOR_PLUGIN_H
+#define DATADOG_PHP_STACK_COLLECTOR_PLUGIN_H
+
+#include <Zend/zend_extensions.h>
+#include <stdbool.h>
+
+void datadog_php_stack_collector_startup(zend_extension *extension);
+void datadog_php_stack_collector_first_activate(bool profiling_enabled);
+void datadog_php_stack_collector_activate(void);
+void datadog_php_stack_collector_deactivate(void);
+
+#endif // DATADOG_PHP_STACK_COLLECTOR_PLUGIN_H

--- a/profiling/stack-collector/CMakeLists.txt
+++ b/profiling/stack-collector/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(datadog-php-stack-collector OBJECT stack-collector.c stack-collector.h)
+
+target_include_directories(datadog-php-stack-collector
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+)
+
+target_compile_features(datadog-php-stack-collector
+  INTERFACE c_std_99
+  PRIVATE c_std_11
+)
+
+target_link_libraries(datadog-php-stack-collector
+  PUBLIC datadog-php-stack-sample
+  PRIVATE datadog_php_string_view PhpConfig::PhpConfig
+)

--- a/profiling/stack-collector/stack-collector.c
+++ b/profiling/stack-collector/stack-collector.c
@@ -1,0 +1,101 @@
+#include "stack-collector.h"
+
+#include <Zend/zend_compile.h>
+#include <Zend/zend_portability.h>
+
+typedef datadog_php_string_view string_view_t;
+
+void datadog_php_stack_collect(zend_execute_data *execute_data,
+                               datadog_php_stack_sample *sample) {
+  datadog_php_stack_sample_ctor(sample);
+
+  for (uint16_t depth = 0;
+       depth < datadog_php_stack_sample_max_depth && execute_data;
+       execute_data = execute_data->prev_execute_data) {
+    zend_function *func = execute_data->func;
+
+    datadog_php_stack_sample_frame frame = {
+        .function = {0, NULL},
+        .file = {0, NULL},
+        .lineno = 0,
+    };
+
+    /* This may be a dummy frame. Dummy frames are often used by require/include
+     * but as far as I know there aren't any flags on the execute_data to let
+     * you know that's where it came from.
+     */
+    if (EXPECTED(func)) {
+      /* User functions do not have a module; if we can ever extract info from
+       * composer packages then we could perhaps use that.
+       */
+      string_view_t module = {0, NULL};
+      if (func->type == ZEND_INTERNAL_FUNCTION &&
+          func->internal_function.module &&
+          func->internal_function.module->name) {
+        const char *name = func->internal_function.module->name;
+        module = (string_view_t){strlen(name), name};
+      }
+
+      zend_string *objname =
+          func->common.scope ? func->common.scope->name : NULL;
+
+      string_view_t Class = {objname ? objname->len : 0,
+                             objname ? objname->val : ""};
+
+      zend_string *fname = func->common.function_name;
+
+      string_view_t Func = {fname ? fname->len : 0, fname ? fname->val : ""};
+      char buffer[256u]; // 256 bytes should be enough for anyone... right?
+
+      // uggggggggggggggggggghhhh... format strings
+      const char fmt[] = "%.*s%s%.*s%s%.*s";
+      /*                  │   │ │   │ └ function or method name
+       *                  │   │ │   └ :: or empty if function
+       *                  │   │ └ class name or empty if function
+       *                  │   └ vertical bar or empty if no package
+       *                  └ package name or empty
+       */
+
+      int result =
+          snprintf(buffer, sizeof buffer, fmt, (int)module.len, module.ptr,
+                   module.len ? "|" : "", (int)Class.len, Class.ptr,
+                   Class.len ? "::" : "", (int)Func.len, Func.ptr);
+
+      if (UNEXPECTED(result < 0 || ((size_t)result) >= sizeof buffer)) {
+        continue;
+      }
+
+      frame.function = (string_view_t){result, buffer};
+      if (func->type == ZEND_USER_FUNCTION) {
+        zend_string *file = func->op_array.filename;
+        if (file) {
+          frame.file = (string_view_t){file->len, file->val};
+        }
+        if (execute_data->opline) {
+          frame.lineno = execute_data->opline->lineno;
+        }
+      }
+
+      if (UNEXPECTED(!frame.function.len && !frame.file.len)) {
+        // No file nor function -> skip the frame (do not increase depth)
+        continue;
+      }
+
+      if (frame.file.len && !frame.function.len) {
+        // we'll use a fake name when there isn't one.
+        frame.function = (string_view_t){sizeof("<php>") - 1, "<php>"};
+      }
+
+      if (UNEXPECTED(!datadog_php_stack_sample_try_add(sample, frame))) {
+        // todo: is the top sample valid? (probably not)
+        break;
+      }
+
+      ++depth;
+    } else {
+      /* Skip this frame because it is missing the zend_function (e.g. a 'dummy'
+       * frame), therefore do not increase the depth.
+       */
+    }
+  }
+}

--- a/profiling/stack-collector/stack-collector.h
+++ b/profiling/stack-collector/stack-collector.h
@@ -1,0 +1,10 @@
+#ifndef DATADOG_PHP_STACK_COLLECTOR_H
+#define DATADOG_PHP_STACK_COLLECTOR_H
+
+#include <components/stack-sample/stack-sample.h>
+
+typedef struct _zend_execute_data zend_execute_data;
+
+void datadog_php_stack_collect(zend_execute_data *, datadog_php_stack_sample *);
+
+#endif // DATADOG_PHP_STACK_COLLECTOR_H


### PR DESCRIPTION
This imports version 0.3.0 of the profiler from the private repository
it used while under development. It is missing some of the supporting
files like docker containers, CI infra, etc to reduce the amount of
scope for security folks to audit for going public.

Aside from these omissions, the only other change is the README. It has
been rewritten to better serve its new audience.