### PR TITLE
Do less work in stack collector when disabled

### DIFF
--- a/profiling/datadog-profiling.c
+++ b/profiling/datadog-profiling.c
@@ -52,6 +52,8 @@ static bool detect_profiling_enabled(const char *value, sapi_t sapi) {
   string_view_t enabled = datadog_php_string_view_from_cstr(value);
   if (datadog_php_string_view_is_boolean_true(enabled))
     return true;
+
+  // todo: when merging with the tracer, default all SAPIs to off, not just CLI
   return sapi == DATADOG_PHP_SAPI_CLI ? false : enabled.len == 0;
 }
 
@@ -61,6 +63,12 @@ static void diagnose_profiling_enabled(bool enabled) {
   if (enabled) {
     string = "[Datadog Profiling] Profiling is enabled.";
   } else {
+    /* This message might not be logged. I've see-sawed back-and-forth on
+     * whether *_ENABLED=off + *_LOG_LEVEL=info should actually do anything. On
+     * one hand, the profiler is off and shouldn't do anything. On the other,
+     * if the log level is set to something, reminding people that it's set to
+     * off may be useful.
+     */
     string = "[Datadog Profiling] Profiling is disabled.";
   }
 

--- a/profiling/plugins/stack_collector_plugin/stack_collector_plugin.c
+++ b/profiling/plugins/stack_collector_plugin/stack_collector_plugin.c
@@ -29,6 +29,10 @@ ZEND_TLS int64_t zend_thread_id;
 static _Atomic bool enabled;
 
 void datadog_php_stack_collector_first_activate(bool profiling_enabled) {
+  enabled = profiling_enabled;
+  if (!profiling_enabled)
+    return;
+
   zend_thread_id = (int64_t)uv_thread_self();
 
   if (datadog_php_profiling_cpu_time_enabled) {
@@ -45,8 +49,6 @@ void datadog_php_stack_collector_first_activate(bool profiling_enabled) {
       return;
     }
   }
-
-  enabled = profiling_enabled;
 }
 
 /* By default, no interrupt function is set. Other extensions may set one, and


### PR DESCRIPTION
While discussing the risk factors of including the profiler but
disabling it, the team decided that the code that always runs should be
audited. Based on source code analysis as well as stepping through the
debugger, this is the only place where substantially more code is
running than there needs to be, in my opinion. Of course, others are
welcome to audit it as well.

Also add some comments; while auditing the code I thought these things
might be worth pointing out.