### PR TITLE
Rename cmake project to datadog-php-profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
  ]]
 cmake_minimum_required(VERSION 3.19)
 
-project(datadog-php-workspace
+project(datadog-php-profiling
   LANGUAGES C CXX
 )
 


### PR DESCRIPTION
The previous name was an old name going way back to when the project
was still being conceptualized.