### PR TITLE
Cpp check static analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .docker-sync.yml
+build/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.docker-sync.yml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,6 @@ project(datadog-php-profiling
   LANGUAGES C CXX
 )
 
-# Verbose build commands
-set(CMAKE_VERBOSE_MAKEFILE on)
-
 # Add cmake/Modules to CMAKE_MODULE_PATH so find_package(PhpConfig) will work
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ project(datadog-php-profiling
   LANGUAGES C CXX
 )
 
+# Verbose build commands
+set(CMAKE_VERBOSE_MAKEFILE on)
+
 # Add cmake/Modules to CMAKE_MODULE_PATH so find_package(PhpConfig) will work
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
@@ -135,3 +138,6 @@ target_include_directories(datadog-profiling
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/components>
 )
+
+# Cpp check static analysis
+include(CppCheck)

--- a/CppCheckSuppressions.txt
+++ b/CppCheckSuppressions.txt
@@ -1,0 +1,5 @@
+// To exclude php include warnings (if include libraries are added)
+// *:*/php/.*-nts-ndebug*
+// toomanyconfigs:*
+unknownMacro:*php_datadog-profiling*
+missingIncludeSystem

--- a/cmake/Modules/CppCheck.cmake
+++ b/cmake/Modules/CppCheck.cmake
@@ -1,0 +1,35 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022-Present Datadog, Inc.
+
+find_program(CPP_CHECK_COMMAND NAMES cppcheck)
+if (CPP_CHECK_COMMAND)
+   #The manual : http://cppcheck.sourceforge.net/manual.pdf
+   message("-- CppCheck found : ${CPP_CHECK_COMMAND}")
+
+   # Listing all files to check manually (we could also use existing variables)
+   file(GLOB_RECURSE CPPCHECK_ALL_SOURCE_FILES profiling/*.c profiling/*.h components/*.c components/*.h)
+   set(CPPCHECK_TEMPLATE "cppcheck:{id}:{file}:{line}:{severity}:{message}")
+
+   list(APPEND CPPCHECK_INCLUDE_CMD "-I${CMAKE_SOURCE_DIR}/profiling/")
+   list(APPEND CPPCHECK_INCLUDE_CMD "-I${CMAKE_SOURCE_DIR}")
+   # Include directories can help with the analysis when using PHP libraries (though they make things slow !)
+    #foreach(IncludeDir ${PhpConfig_INCLUDE_DIRS})
+    #     list(APPEND CPPCHECK_INCLUDE_CMD "-I${IncludeDir}")
+    #  endforeach()
+
+   list(APPEND CPP_CHECK_COMMAND 
+         "--enable=warning,performance,portability,information,style"
+         "--template=${CPPCHECK_TEMPLATE}"
+         "--quiet" 
+         "--suppressions-list=${CMAKE_SOURCE_DIR}/CppCheckSuppressions.txt"
+         ${CPPCHECK_INCLUDE_CMD}
+         )
+
+   add_custom_target(
+      cppcheck
+      COMMAND ${CPP_CHECK_COMMAND}
+      --error-exitcode=1 # make sure CI pipeline fails
+    #   --check-config #check what header files are missing
+      ${CPPCHECK_ALL_SOURCE_FILES}
+      )
+endif()

--- a/cmake/Modules/CppCheck.cmake
+++ b/cmake/Modules/CppCheck.cmake
@@ -3,33 +3,29 @@
 
 find_program(CPP_CHECK_COMMAND NAMES cppcheck)
 if (CPP_CHECK_COMMAND)
-   #The manual : http://cppcheck.sourceforge.net/manual.pdf
-   message("-- CppCheck found : ${CPP_CHECK_COMMAND}")
+#The manual : http://cppcheck.sourceforge.net/manual.pdf
+  message("-- CppCheck found : ${CPP_CHECK_COMMAND}")
 
-   # Listing all files to check manually (we could also use existing variables)
-   file(GLOB_RECURSE CPPCHECK_ALL_SOURCE_FILES profiling/*.c profiling/*.h components/*.c components/*.h)
-   set(CPPCHECK_TEMPLATE "cppcheck:{id}:{file}:{line}:{severity}:{message}")
+  # Listing all files to check manually (we could also use existing variables)
+  file(GLOB_RECURSE CPPCHECK_ALL_SOURCE_FILES profiling/*.c profiling/*.h components/*.c components/*.h)
+  set(CPPCHECK_TEMPLATE "cppcheck:{id}:{file}:{line}:{severity}:{message}")
 
-   list(APPEND CPPCHECK_INCLUDE_CMD "-I${CMAKE_SOURCE_DIR}/profiling/")
-   list(APPEND CPPCHECK_INCLUDE_CMD "-I${CMAKE_SOURCE_DIR}")
-   # Include directories can help with the analysis when using PHP libraries (though they make things slow !)
-    #foreach(IncludeDir ${PhpConfig_INCLUDE_DIRS})
-    #     list(APPEND CPPCHECK_INCLUDE_CMD "-I${IncludeDir}")
-    #  endforeach()
+  list(APPEND CPPCHECK_INCLUDE_CMD "-I${CMAKE_SOURCE_DIR}/profiling/")
+  list(APPEND CPPCHECK_INCLUDE_CMD "-I${CMAKE_SOURCE_DIR}")
 
-   list(APPEND CPP_CHECK_COMMAND 
-         "--enable=warning,performance,portability,information,style"
-         "--template=${CPPCHECK_TEMPLATE}"
-         "--quiet" 
-         "--suppressions-list=${CMAKE_SOURCE_DIR}/CppCheckSuppressions.txt"
-         ${CPPCHECK_INCLUDE_CMD}
-         )
+  list(APPEND CPP_CHECK_COMMAND 
+      "--enable=warning,performance,portability,information,style"
+      "--template=${CPPCHECK_TEMPLATE}"
+      "--quiet" 
+      "--suppressions-list=${CMAKE_SOURCE_DIR}/CppCheckSuppressions.txt"
+      ${CPPCHECK_INCLUDE_CMD}
+      )
 
-   add_custom_target(
+  add_custom_target(
       cppcheck
       COMMAND ${CPP_CHECK_COMMAND}
       --error-exitcode=1 # make sure CI pipeline fails
-    #   --check-config #check what header files are missing
+      # --check-config #check what header files are missing
       ${CPPCHECK_ALL_SOURCE_FILES}
       )
 endif()

--- a/profiling/plugins/recorder_plugin/recorder_plugin.c
+++ b/profiling/plugins/recorder_plugin/recorder_plugin.c
@@ -559,12 +559,12 @@ static bool recorder_first_activate_helper() {
   }
 
   // todo: DD_SITE + DD_API_KEY
-  const char *path = "/profiling/v1/input";
   datadog_php_arena *arena = globals.arena;
 
   // prioritize URL over HOST + PORT
   string url = datadog_php_profiler_getenv(SV("DD_TRACE_AGENT_URL"), arena);
   if (!url.len || !url.data[0]) {
+    const char *path = "/profiling/v1/input";
 
     string env_host = datadog_php_profiler_getenv(SV("DD_AGENT_HOST"), arena);
     const char *host =


### PR DESCRIPTION
# Description 

Add a build target in the CMake files to trigger a cppcheck analysis.
This is triggered only if cppcheck is available. 
This includes a files on what should be ignored in cppcheck warnings.

# Motivation

Cpp check can catch logic errors at build time.
We can add further customisation steps to cpp check

# Next step

Plug the check in CI worklfows.
A first PR is available in the gitlab CI flow. 
