### PR TITLE
Allow building for PHP 8.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ variables:
   # These are gitlab variables so that it's easier to do a manual deploy
   # If these are set witih value and description, then it gives you UI elements
   DOWNSTREAM_BRANCH:
-    value: "main"
+    value: "php-8.1"
     description: "Run a specific branch downstream"
 
 trigger_internal_build:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ variables:
   # These are gitlab variables so that it's easier to do a manual deploy
   # If these are set witih value and description, then it gives you UI elements
   DOWNSTREAM_BRANCH:
-    value: "php-8.1"
+    value: "main"
     description: "Run a specific branch downstream"
 
 trigger_internal_build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if(DATADOG_PHP_TESTING)
 endif ()
 
 find_package(Threads REQUIRED)
-find_package(PhpConfig 7.1...8.1 REQUIRED)
+find_package(PhpConfig 7.1...<8.2 REQUIRED)
 find_package(PkgConfig REQUIRED)
 
 #[[ Prefer libuv-static, but note that it needs to be built with Position


### PR DESCRIPTION
This isn't tested and verified, but it does compile. PHP 8.1 has the
concept of Fibers which are not supported -- it collects the stack for
whatever fiber is running at the time of interrupt.