### PR TITLE
Expose datadog_profiling_interrupt_function

### DIFF
--- a/datadog-profiling.sym
+++ b/datadog-profiling.sym
@@ -2,6 +2,8 @@ DATADOG_PROFILER_0.1.0 {
 global:
         zend_extension_entry;
         extension_version_info;
+        datadog_profiling_interrupt_function;
+
 local:
         *;
 };

--- a/profiling/php_datadog-profiling.h
+++ b/profiling/php_datadog-profiling.h
@@ -13,6 +13,8 @@ void datadog_profiling_deactivate(void);
 void datadog_profiling_shutdown(zend_extension *);
 void datadog_profiling_diagnostics(void);
 
+ZEND_API void datadog_profiling_interrupt_function(struct _zend_execute_data *);
+
 #if defined(ZTS)
 ZEND_TSRMLS_CACHE_EXTERN()
 #endif

--- a/profiling/plugins/stack_collector_plugin/stack_collector_plugin.c
+++ b/profiling/plugins/stack_collector_plugin/stack_collector_plugin.c
@@ -354,6 +354,11 @@ static void datadog_php_stack_collector_interrupt_function(
                                      &thread_globals.sample);
 }
 
+ZEND_API void
+datadog_profiling_interrupt_function(zend_execute_data *execute_data) {
+  datadog_php_stack_collector_interrupt_function(execute_data);
+}
+
 static void datadog_php_stack_collector_interrupt_function_helper(
     zend_execute_data *execute_data) {
   datadog_php_stack_collector_interrupt_function(execute_data);


### PR DESCRIPTION
This function should be called from the tracer if there's a point
where it wants to make sure any pending interrupt has been handled
before it does something. This can be used to fix a bug explained in
the corresponding ddtrace PR:

https://github.com/DataDog/dd-trace-php/pull/1499