### PR TITLE
Integrate phpt tests into CMakeLists.txt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,13 +39,16 @@ jobs:
               -C /opt/cmake
 
       - run:
-          name: Build datadog-profiling
+          name: Build datadog-profiling and run tests
           command: |
             set -euo pipefail
             export DDProf_ROOT="/opt/libddprof"
             export PATH="/opt/cmake/bin:$PATH"
-            cmake -S . -B cmake-build-release -DCMAKE_BUILD_TYPE=Release
+            cmake -S . -B cmake-build-release \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DDATADOG_PHP_TESTING=on
             cmake --build cmake-build-release
+            cmake --build cmake-build-release --target test
 
       - run:
           name: Install datadog-profiling
@@ -67,16 +70,6 @@ jobs:
             # [Datadog Profiling] Failed to upload profile
             # It should NOT have non-zero exit code.
             DD_PROFILING_ENABLED=yes php --ri datadog-profiling
-
-      - run:
-          name: Run .phpt tests
-          command: |
-            # Honestly, these should be a separate "job" but didn't want to
-            # duplicate installing packages and such.
-            set -euo pipefail
-            extension_dir="$(php-config --extension-dir)"
-            cp -v "$extension_dir/build/run-tests.php" .
-            php run-tests.php tests/phpt
 
   nightly:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,12 +37,32 @@ jobs:
             tar -x --strip-components 1 \
               -f cmake-3.22.1-linux-x86_64.tar.gz \
               -C /opt/cmake
+            curl -OL https://github.com/catchorg/Catch2/archive/refs/tags/v2.13.8.tar.gz
+            sha256sum="b9b592bd743c09f13ee4bf35fc30eeee2748963184f6bea836b146e6cc2a585a"
+            echo "$sha256sum  v2.13.8.tar.gz"
+            mkdir -vp /tmp/catch2-src /tmp/catch2-build
+            sudo mkdir -vp /opt/catch2
+            sudo chown $user /opt/catch2
+            tar -x --strip-components 1 \
+              -f v2.13.8.tar.gz \
+              -C /tmp/catch2-src
+            cmake -S /tmp/catch2-src -B /tmp/catch2-build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=/opt/catch2 \
+              -DBUILD_SHARED_LIBS=on \
+              -DCMAKE_POSITION_INDEPENDENT_CODE=on \
+              -DCATCH_INSTALL_DOCS=off \
+              -DCATCH_BUILD_TESTING=off \
+              -DCATCH_BUILD_STATIC_LIBRARY=on
+            cmake --build /tmp/catch2-build --parallel $(nproc)
+            cmake --install /tmp/catch2-build
 
       - run:
           name: Build datadog-profiling and run tests
           command: |
             set -euo pipefail
             export DDProf_ROOT="/opt/libddprof"
+            export Catch2_ROOT="/opt/catch2"
             export PATH="/opt/cmake/bin:$PATH"
             cmake -S . -B cmake-build-release \
               -DCMAKE_BUILD_TYPE=Release \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,8 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release \
               -DDATADOG_PHP_TESTING=on
             cmake --build cmake-build-release
-            cmake --build cmake-build-release --target test
+            cd cmake-build-release
+            ctest --output-on-failure
 
       - run:
           name: Install datadog-profiling

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ add_library(
 #[[ Note that linking directly to libc dynamically is actually important!
     Without it, on Alpine it will sometimes link libc in statically, and then
     we hide the symbols with a linker script, and then __vdsosym will fail to
-    find symbols in libc like like clock_gettime!
+    find symbols in libc like clock_gettime!
  ]]
 target_link_libraries(
   datadog-profiling

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,7 @@
  ]]
 cmake_minimum_required(VERSION 3.19)
 
-project(datadog-php-profiling
-  LANGUAGES C CXX
-)
+project(datadog-php-profiling LANGUAGES C CXX)
 
 # Add cmake/Modules to CMAKE_MODULE_PATH so find_package(PhpConfig) will work
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
@@ -21,9 +19,15 @@ if(UNIX) # This is probably a bit too broad
   ]]
   if(CMAKE_BUILD_TYPE)
     get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-    get_property(allowedBuildTypes CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS)
+    get_property(
+      allowedBuildTypes
+      CACHE CMAKE_BUILD_TYPE
+      PROPERTY STRINGS)
     if(NOT isMultiConfig AND NOT CMAKE_BUILD_TYPE IN_LIST allowedBuildTypes)
-      message(FATAL_ERROR "Invalid build type: ${CMAKE_BUILD_TYPE}; allowed build types: ${allowedBuildTypes}")
+      message(
+        FATAL_ERROR
+          "Invalid build type: ${CMAKE_BUILD_TYPE}; allowed build types: ${allowedBuildTypes}"
+      )
     endif()
   endif()
 endif()
@@ -38,25 +42,23 @@ if(DATADOG_PHP_TESTING)
   find_package(Catch2 REQUIRED)
   include(Catch)
 
-  if (NOT TARGET Catch2::Catch2WithMain AND TARGET Catch2::Catch2)
+  if(NOT TARGET Catch2::Catch2WithMain AND TARGET Catch2::Catch2)
     #[[ The build of catch2 we are using wasn't configured with
         `CATCH_BUILD_STATIC_LIBRARY`; let's polyfill it.
     ]]
     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/catch2withmain.cc
-      "#define CATCH_CONFIG_MAIN\n"
-      "#include <catch2/catch.hpp>\n"
-    )
+         "#define CATCH_CONFIG_MAIN\n" "#include <catch2/catch.hpp>\n")
 
     add_library(Catch2WithMain ${CMAKE_CURRENT_BINARY_DIR}/catch2withmain.cc)
     target_compile_features(Catch2WithMain INTERFACE cxx_std_11)
     target_link_libraries(Catch2WithMain PUBLIC Catch2::Catch2)
     add_library(Catch2::Catch2WithMain ALIAS Catch2WithMain)
-  endif ()
+  endif()
 
-  if (NOT TARGET Catch2::Catch2WithMain)
+  if(NOT TARGET Catch2::Catch2WithMain)
     message(FATAL_ERROR "Catch2WithMain not found and polyfill failed.")
-  endif ()
-endif ()
+  endif()
+endif()
 
 find_package(Threads REQUIRED)
 find_package(PhpConfig 7.1...<8.2 REQUIRED)
@@ -66,7 +68,7 @@ find_package(PkgConfig REQUIRED)
     Independent Code (PIC).
  ]]
 pkg_check_modules(UV IMPORTED_TARGET libuv-static)
-if (NOT UV_FOUND)
+if(NOT UV_FOUND)
   pkg_check_modules(UV REQUIRED IMPORTED_TARGET libuv)
 endif()
 
@@ -76,47 +78,42 @@ find_package(DDProf REQUIRED)
 
 add_subdirectory(profiling)
 
-add_library(datadog-profiling MODULE
+add_library(
+  datadog-profiling MODULE
   datadog-profiling.c
   profiling/datadog-profiling.c
   profiling/datadog-profiling.h
   profiling/plugins/log_plugin/log_plugin.c
   profiling/plugins/recorder_plugin/recorder_plugin.c
-  profiling/plugins/stack_collector_plugin/stack_collector_plugin.c
-)
+  profiling/plugins/stack_collector_plugin/stack_collector_plugin.c)
 
-target_link_libraries(datadog-profiling
-  PRIVATE
-    datadog-php-arena
-    datadog-php-channel
-    datadog-php-config
-    datadog-php-env
-    datadog-php-log
-    datadog_php_sapi
-    datadog-php-stack-collector
-    datadog-php-stack-sample
-    datadog_php_string_view
-    datadog-php-time
-    DDProf::FFI
-    PkgConfig::UV
-    PhpConfig::PhpConfig
-    Threads::Threads
-  PUBLIC
-    #[[
-      Note that this is actually important! Without it, on Alpine it will
-      sometimes link libc in statically, and then we hide the symbols with a
-      linker script, and then __vdsosym will fail to find symbols in libc like
-      like clock_gettime! This means the libc's symbols that get called by VDSO
-      need to be public, and publishing libc's symbols as part of Datadog's
-      libraries would be setting us up for symbol conflict failures.
-    ]]
-    -lc
-)
+#[[ Note that linking directly to libc dynamically is actually important!
+    Without it, on Alpine it will sometimes link libc in statically, and then
+    we hide the symbols with a linker script, and then __vdsosym will fail to
+    find symbols in libc like like clock_gettime!
+ ]]
+target_link_libraries(
+  datadog-profiling
+  PRIVATE datadog-php-arena
+          datadog-php-channel
+          datadog-php-config
+          datadog-php-env
+          datadog-php-log
+          datadog_php_sapi
+          datadog-php-stack-collector
+          datadog-php-stack-sample
+          datadog_php_string_view
+          datadog-php-time
+          DDProf::FFI
+          PkgConfig::UV
+          PhpConfig::PhpConfig
+          Threads::Threads
+  PUBLIC -lc)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-  set_target_properties(datadog-profiling PROPERTIES
-    LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/datadog-profiling.sym
-  )
+  set_target_properties(
+    datadog-profiling
+    PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/datadog-profiling.sym)
 
   include(CheckCCompilerFlag)
   check_c_compiler_flag(-static-libgcc HAS_STATIC_LIBGCC)
@@ -125,18 +122,24 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     target_link_options(datadog-profiling PRIVATE -static-libgcc)
   endif()
 
-  target_link_options(datadog-profiling PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/datadog-profiling.sym)
+  target_link_options(
+    datadog-profiling PRIVATE
+    -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/datadog-profiling.sym)
 endif()
 
-set_target_properties(datadog-profiling PROPERTIES
-  PREFIX "" # PHP modules are not prefixed with lib*
-  C_VISIBILITY_PRESET hidden
-)
+set_target_properties(
+  datadog-profiling
+  PROPERTIES PREFIX "" # PHP modules are not prefixed with lib*
+             C_VISIBILITY_PRESET hidden)
 
-target_include_directories(datadog-profiling
+target_include_directories(
+  datadog-profiling
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/components>
-)
+  PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/components>)
 
 # Cpp check static analysis
 include(CppCheck)
+
+if(DATADOG_PHP_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/cmake/Modules/FindPhpConfig.cmake
+++ b/cmake/Modules/FindPhpConfig.cmake
@@ -26,6 +26,9 @@ find_program(PhpConfig_EXECUTABLE
     - <PackageName>_VERSION_MAJOR (used)
     - <PackageName>_VERSION_MINOR (used)
     - <PackageName>_VERSION_PATCH (used)
+
+    The following variables are defined as well:
+    - PhpConfig_PHP_BINARY
  ]]
 
 if(PhpConfig_EXECUTABLE)
@@ -79,6 +82,13 @@ if(PhpConfig_EXECUTABLE)
 
   string(REGEX REPLACE "[0-9]+([0-9][0-9])$" "\\1" PhpConfig_VERSION_PATCH "${PhpConfig_VERNUM}")
   string(REGEX REPLACE "^0([0-9])$" "\\1" PhpConfig_VERSION_PATCH "${PhpConfig_VERSION_PATCH}")
+
+  execute_process(COMMAND ${PhpConfig_EXECUTABLE} --php-binary
+    RESULT_VARIABLE PhpConfig_PHP_BINARY_RESULT
+    OUTPUT_VARIABLE PhpConfig_PHP_BINARY
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+  )
 endif()
 
 find_package_handle_standard_args(PhpConfig

--- a/components/arena/CMakeLists.txt
+++ b/components/arena/CMakeLists.txt
@@ -1,14 +1,13 @@
 add_library(datadog-php-arena OBJECT arena.c)
 
-target_include_directories(datadog-php-arena
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
-)
+target_include_directories(
+  datadog-php-arena PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>)
 
-target_compile_features(datadog-php-arena
+target_compile_features(
+  datadog-php-arena
   INTERFACE c_std_99
-  PRIVATE c_std_11
-)
+  PRIVATE c_std_11)
 
-if (DATADOG_PHP_TESTING)
+if(DATADOG_PHP_TESTING)
   add_subdirectory(tests)
-endif ()
+endif()

--- a/components/arena/tests/CMakeLists.txt
+++ b/components/arena/tests/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_executable(test-datadog-php-arena arena.cc)
-target_link_libraries(test-datadog-php-arena
-  PRIVATE Catch2::Catch2WithMain datadog-php-arena
-)
+target_link_libraries(test-datadog-php-arena PRIVATE Catch2::Catch2WithMain
+                                                     datadog-php-arena)
 
 catch_discover_tests(test-datadog-php-arena)

--- a/components/channel/CMakeLists.txt
+++ b/components/channel/CMakeLists.txt
@@ -1,20 +1,19 @@
 add_library(datadog-php-channel channel.c)
-target_include_directories(datadog-php-channel
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
-)
+target_include_directories(
+  datadog-php-channel
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>)
 
-target_compile_features(datadog-php-channel
+target_compile_features(
+  datadog-php-channel
   INTERFACE c_std_99
-  PRIVATE c_std_11
-)
+  PRIVATE c_std_11)
 
 # libuv's pc file doesn't put -pthread into its link line, but it depends on it
 # for all our current platforms.
 find_package(Threads REQUIRED)
 target_link_libraries(datadog-php-channel
-  PRIVATE datadog-php-queue PkgConfig::UV Threads::Threads
-)
+                      PRIVATE datadog-php-queue PkgConfig::UV Threads::Threads)
 
-if (DATADOG_PHP_TESTING)
+if(DATADOG_PHP_TESTING)
   add_subdirectory(tests)
-endif ()
+endif()

--- a/components/channel/tests/CMakeLists.txt
+++ b/components/channel/tests/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_executable(test-datadog-php-channel channel.cc)
 
-target_link_libraries(test-datadog-php-channel
-  PRIVATE Catch2::Catch2WithMain datadog-php-channel PkgConfig::UV
-)
+target_link_libraries(
+  test-datadog-php-channel PRIVATE Catch2::Catch2WithMain datadog-php-channel
+                                   PkgConfig::UV)
 
 # Channels have deadlock opportunities, so set a timeout
 catch_discover_tests(test-datadog-php-channel PROPERTIES TIMEOUT 20)

--- a/components/log/CMakeLists.txt
+++ b/components/log/CMakeLists.txt
@@ -1,16 +1,15 @@
 add_library(datadog-php-log OBJECT log.c)
 
-target_include_directories(datadog-php-log
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
-)
+target_include_directories(
+  datadog-php-log PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>)
 
-target_compile_features(datadog-php-log
+target_compile_features(
+  datadog-php-log
   INTERFACE c_std_99
-  PRIVATE c_std_11
-)
+  PRIVATE c_std_11)
 
 target_link_libraries(datadog-php-log PUBLIC datadog_php_string_view)
 
-if (DATADOG_PHP_TESTING)
+if(DATADOG_PHP_TESTING)
   add_subdirectory(tests)
-endif ()
+endif()

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -172,3 +172,21 @@ void datadog_php_log_level_set(logger_t *logger, log_level_t level) {
     pthread_mutex_unlock(logger->mutex);
   }
 }
+
+const char *datadog_php_log_level_to_str(datadog_php_log_level level) {
+  switch (level) {
+  default:
+  case DATADOG_PHP_LOG_UNKNOWN:
+    return "unknown";
+  case DATADOG_PHP_LOG_OFF:
+    return "off";
+  case DATADOG_PHP_LOG_ERROR:
+    return "error";
+  case DATADOG_PHP_LOG_WARN:
+    return "warn";
+  case DATADOG_PHP_LOG_INFO:
+    return "info";
+  case DATADOG_PHP_LOG_DEBUG:
+    return "debug";
+  }
+}

--- a/components/log/log.h
+++ b/components/log/log.h
@@ -102,6 +102,13 @@ void datadog_php_log_level_set(datadog_php_logger *, datadog_php_log_level);
  */
 datadog_php_log_level datadog_php_log_level_detect(datadog_php_string_view val);
 
+/**
+ * Converts the provide log `level` to a static string.
+ * @param level
+ * @return A string
+ */
+const char *datadog_php_log_level_to_str(datadog_php_log_level level);
+
 #undef C_STATIC
 
 #endif // DATADOG_PHP_PROFILER_LOG_H

--- a/components/log/tests/CMakeLists.txt
+++ b/components/log/tests/CMakeLists.txt
@@ -2,8 +2,8 @@ add_executable(test-datadog-php-log log.cc)
 
 find_package(Threads REQUIRED)
 
-target_link_libraries(test-datadog-php-log
-  PRIVATE Catch2::Catch2WithMain datadog-php-log datadog_php_string_view Threads::Threads
-)
+target_link_libraries(
+  test-datadog-php-log PRIVATE Catch2::Catch2WithMain datadog-php-log
+                               datadog_php_string_view Threads::Threads)
 
 catch_discover_tests(test-datadog-php-log)

--- a/components/log/tests/log.cc
+++ b/components/log/tests/log.cc
@@ -116,3 +116,18 @@ TEST_CASE("detect unknown log levels", "[log]") {
     CHECK(log_level == DATADOG_PHP_LOG_UNKNOWN);
   }
 }
+
+TEST_CASE("log level to string", "[log]") {
+  struct {
+    const char *str;
+    datadog_php_log_level level;
+  } values[] = {
+      {"unknown", DATADOG_PHP_LOG_UNKNOWN},  {"off", DATADOG_PHP_LOG_OFF},
+      {"error", DATADOG_PHP_LOG_ERROR},      {"warn", DATADOG_PHP_LOG_WARN},
+      {"info", DATADOG_PHP_LOG_INFO},        {"debug", DATADOG_PHP_LOG_DEBUG},
+      {"unknown", (datadog_php_log_level)-4}};
+
+  for (auto value : values) {
+    CHECK(value.str == datadog_php_log_level_to_str(value.level));
+  }
+}

--- a/components/queue/CMakeLists.txt
+++ b/components/queue/CMakeLists.txt
@@ -1,13 +1,12 @@
 add_library(datadog-php-queue queue.c)
-target_include_directories(datadog-php-queue
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
-)
+target_include_directories(
+  datadog-php-queue PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>)
 
-target_compile_features(datadog-php-queue
+target_compile_features(
+  datadog-php-queue
   INTERFACE c_std_99
-  PRIVATE c_std_11
-)
+  PRIVATE c_std_11)
 
-if (DATADOG_PHP_TESTING)
+if(DATADOG_PHP_TESTING)
   add_subdirectory(tests)
-endif ()
+endif()

--- a/components/queue/tests/CMakeLists.txt
+++ b/components/queue/tests/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_executable(test-datadog-php-queue queue.cc)
-target_link_libraries(test-datadog-php-queue
-  PRIVATE Catch2::Catch2WithMain datadog-php-queue
-)
+target_link_libraries(test-datadog-php-queue PRIVATE Catch2::Catch2WithMain
+                                                     datadog-php-queue)
 
 catch_discover_tests(test-datadog-php-queue)

--- a/components/queue/tests/queue.cc
+++ b/components/queue/tests/queue.cc
@@ -6,7 +6,8 @@ extern "C" {
 
 TEST_CASE("empty queue operations", "[queue]") {
   datadog_php_queue queue;
-  REQUIRE(datadog_php_queue_ctor(&queue, 0, nullptr));
+  void *buffer[1];
+  REQUIRE(datadog_php_queue_ctor(&queue, 0, buffer));
 
   void *item = nullptr;
   REQUIRE(!datadog_php_queue_try_push(&queue, item));

--- a/components/sapi/CMakeLists.txt
+++ b/components/sapi/CMakeLists.txt
@@ -1,33 +1,21 @@
 add_library(datadog_php_sapi sapi.c)
 
-target_include_directories(datadog_php_sapi
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
-    $<INSTALL_INTERFACE:include>
-)
+target_include_directories(
+  datadog_php_sapi PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+                          $<INSTALL_INTERFACE:include>)
 
-target_compile_features(datadog_php_sapi
-  PUBLIC c_std_99
-)
+target_compile_features(datadog_php_sapi PUBLIC c_std_99)
 
-set_target_properties(datadog_php_sapi PROPERTIES
-  EXPORT_NAME Sapi
-)
+set_target_properties(datadog_php_sapi PROPERTIES EXPORT_NAME Sapi)
 
-target_link_libraries(datadog_php_sapi
-  PUBLIC Datadog::Php::StringView
-)
+target_link_libraries(datadog_php_sapi PUBLIC Datadog::Php::StringView)
 
-add_library(Datadog::Php::Sapi
-  ALIAS datadog_php_sapi
-)
+add_library(Datadog::Php::Sapi ALIAS datadog_php_sapi)
 
-if (${DATADOG_PHP_TESTING})
+if(${DATADOG_PHP_TESTING})
   add_subdirectory(tests)
-endif ()
+endif()
 
 # This copies the include files when `install` is ran
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/sapi.h
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/sapi/
-)
-
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/sapi/)

--- a/components/sapi/tests/CMakeLists.txt
+++ b/components/sapi/tests/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_executable(sapi sapi.cc)
 
-target_link_libraries(sapi
-  PUBLIC Catch2::Catch2WithMain Datadog::Php::Sapi
-)
+target_link_libraries(sapi PUBLIC Catch2::Catch2WithMain Datadog::Php::Sapi)
 
 catch_discover_tests(sapi)

--- a/components/stack-sample/CMakeLists.txt
+++ b/components/stack-sample/CMakeLists.txt
@@ -1,13 +1,13 @@
 add_library(datadog-php-stack-sample OBJECT stack-sample.c stack-sample.h)
 
-target_include_directories(datadog-php-stack-sample
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
-)
+target_include_directories(
+  datadog-php-stack-sample
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>)
 
 target_compile_features(datadog-php-stack-sample PUBLIC c_std_11)
 
 target_link_libraries(datadog-php-stack-sample PUBLIC datadog_php_string_view)
 
-if (DATADOG_PHP_TESTING)
+if(DATADOG_PHP_TESTING)
   add_subdirectory(tests)
-endif ()
+endif()

--- a/components/stack-sample/tests/CMakeLists.txt
+++ b/components/stack-sample/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(test-datadog-php-stack-sample stack-sample.cc)
-target_link_libraries(test-datadog-php-stack-sample
-  PRIVATE Catch2::Catch2WithMain datadog-php-stack-sample datadog_php_string_view
-)
+target_link_libraries(
+  test-datadog-php-stack-sample
+  PRIVATE Catch2::Catch2WithMain datadog-php-stack-sample
+          datadog_php_string_view)
 
 catch_discover_tests(test-datadog-php-stack-sample)

--- a/components/string_view/CMakeLists.txt
+++ b/components/string_view/CMakeLists.txt
@@ -1,29 +1,20 @@
 add_library(datadog_php_string_view string_view.c)
 
-target_include_directories(datadog_php_string_view
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
-    $<INSTALL_INTERFACE:include>
-)
+target_include_directories(
+  datadog_php_string_view
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+         $<INSTALL_INTERFACE:include>)
 
-target_compile_features(datadog_php_string_view
-  PUBLIC c_std_99
-)
+target_compile_features(datadog_php_string_view PUBLIC c_std_99)
 
-set_target_properties(datadog_php_string_view PROPERTIES
-  EXPORT_NAME StringView
-)
+set_target_properties(datadog_php_string_view PROPERTIES EXPORT_NAME StringView)
 
-add_library(Datadog::Php::StringView
-  ALIAS datadog_php_string_view
-)
+add_library(Datadog::Php::StringView ALIAS datadog_php_string_view)
 
-if (${DATADOG_PHP_TESTING})
+if(${DATADOG_PHP_TESTING})
   add_subdirectory(tests)
-endif ()
+endif()
 
 # This copies the include files when `install` is ran
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/string_view.h
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/string_view/
-)
-
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/string_view/)

--- a/components/string_view/tests/CMakeLists.txt
+++ b/components/string_view/tests/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(string_view string_view.cc)
 
-target_link_libraries(string_view
-  PUBLIC Catch2::Catch2WithMain Datadog::Php::StringView
-)
+target_link_libraries(string_view PUBLIC Catch2::Catch2WithMain
+                                         Datadog::Php::StringView)
 
 catch_discover_tests(string_view)

--- a/components/time/CMakeLists.txt
+++ b/components/time/CMakeLists.txt
@@ -1,8 +1,7 @@
 add_library(datadog-php-time OBJECT time.c time.h)
 
-target_include_directories(datadog-php-time
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
-)
+target_include_directories(
+  datadog-php-time PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>)
 
 include(CheckCSourceRuns)
 include(CMakePushCheckState)
@@ -14,7 +13,8 @@ find_package(Threads)
     clock_gettime gets used with pthread_getcpuclockid if the platform has it.
 ]]
 cmake_push_check_state(RESET)
-set(CLOCK_GETTIME_PROGRAM "#include <time.h>
+set(CLOCK_GETTIME_PROGRAM
+    "#include <time.h>
 int main(void) {
   struct timespec ts;
   return clock_gettime(CLOCK_REALTIME, &ts) == 0 ? 0 : 1;
@@ -23,24 +23,26 @@ int main(void) {
 check_c_source_runs("${CLOCK_GETTIME_PROGRAM}" DATADOG_HAVE_CLOCK_GETTIME)
 cmake_pop_check_state()
 
-if (NOT DATADOG_HAVE_CLOCK_GETTIME)
+if(NOT DATADOG_HAVE_CLOCK_GETTIME)
   # Try again with -lrt; use a different cache variable name or it won't run.
   cmake_push_check_state(RESET)
   set(CMAKE_REQUIRED_LIBRARIES -lrt)
   check_c_source_runs("${CLOCK_GETTIME_PROGRAM}" DATADOG_HAVE_CLOCK_GETTIME_RT)
 
-  if (DATADOG_HAVE_CLOCK_GETTIME_RT)
+  if(DATADOG_HAVE_CLOCK_GETTIME_RT)
     target_link_libraries(datadog-php-time PRIVATE -lrt)
-  endif ()
+  endif()
   cmake_pop_check_state()
-endif ()
+endif()
 
-if (DATADOG_HAVE_CLOCK_GETTIME OR DATADOG_HAVE_CLOCK_GETTIME_RT)
-  target_compile_definitions(datadog-php-time PRIVATE -DDATADOG_HAVE_CLOCK_GETTIME=1)
+if(DATADOG_HAVE_CLOCK_GETTIME OR DATADOG_HAVE_CLOCK_GETTIME_RT)
+  target_compile_definitions(datadog-php-time
+                             PRIVATE -DDATADOG_HAVE_CLOCK_GETTIME=1)
 
   cmake_push_check_state(RESET)
   set(CMAKE_REQUIRED_LIBRARIES Threads::Threads)
-  check_c_source_runs("
+  check_c_source_runs(
+    "
   #include <pthread.h>
   #include <time.h>
 
@@ -51,14 +53,17 @@ if (DATADOG_HAVE_CLOCK_GETTIME OR DATADOG_HAVE_CLOCK_GETTIME_RT)
     (void)pthread_getcpuclockid(pthread_self(), &clockid);
     return 0;
   }
-  " DATADOG_HAVE_PTHREAD_GETCPUCLOCKID)
-  if (DATADOG_HAVE_PTHREAD_GETCPUCLOCKID)
-    target_compile_definitions(datadog-php-time PRIVATE -DDATADOG_HAVE_PTHREAD_GETCPUCLOCKID=1)
-  endif ()
+  "
+    DATADOG_HAVE_PTHREAD_GETCPUCLOCKID)
+  if(DATADOG_HAVE_PTHREAD_GETCPUCLOCKID)
+    target_compile_definitions(datadog-php-time
+                               PRIVATE -DDATADOG_HAVE_PTHREAD_GETCPUCLOCKID=1)
+  endif()
   cmake_pop_check_state()
-endif ()
+endif()
 
-check_c_source_runs("#include <mach/mach_init.h>
+check_c_source_runs(
+  "#include <mach/mach_init.h>
 #include <mach/thread_act.h>
 
 int main(void) {
@@ -68,8 +73,10 @@ int main(void) {
 	(void)thread_info(thread, THREAD_BASIC_INFO, (thread_info_t) &info, &count);
 	return 0;
 }
-" DATADOG_HAVE_THREAD_INFO)
+"
+  DATADOG_HAVE_THREAD_INFO)
 
-if (DATADOG_HAVE_THREAD_INFO)
-  target_compile_definitions(datadog-php-time PRIVATE -DDATADOG_HAVE_THREAD_INFO=1)
-endif ()
+if(DATADOG_HAVE_THREAD_INFO)
+  target_compile_definitions(datadog-php-time
+                             PRIVATE -DDATADOG_HAVE_THREAD_INFO=1)
+endif()

--- a/profiling/CMakeLists.txt
+++ b/profiling/CMakeLists.txt
@@ -1,4 +1,3 @@
 add_subdirectory(config)
 add_subdirectory(env)
 add_subdirectory(stack-collector)
-

--- a/profiling/config/CMakeLists.txt
+++ b/profiling/config/CMakeLists.txt
@@ -1,19 +1,15 @@
 add_library(datadog-php-config OBJECT config.c config.h)
 
-target_include_directories(datadog-php-config
-  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
-)
+target_include_directories(
+  datadog-php-config
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
 
-target_compile_features(datadog-php-config
+target_compile_features(
+  datadog-php-config
   INTERFACE c_std_99
-  PRIVATE c_std_11
-)
+  PRIVATE c_std_11)
 
-target_link_libraries(datadog-php-config
-  PUBLIC
-    datadog-php-arena
-    datadog-php-log
-    datadog_php_string_view
-    DDProf::FFI
-  PRIVATE PhpConfig::PhpConfig
-)
+target_link_libraries(
+  datadog-php-config
+  PUBLIC datadog-php-arena datadog-php-log datadog_php_string_view DDProf::FFI
+  PRIVATE PhpConfig::PhpConfig)

--- a/profiling/datadog-profiling.c
+++ b/profiling/datadog-profiling.c
@@ -31,24 +31,6 @@ static uint8_t profiling_env_storage[4096];
 static datadog_php_profiling_env profiling_env;
 static datadog_php_profiling_config profiling_config;
 
-static const char *datadog_php_log_level_to_str(datadog_php_log_level level) {
-  switch (level) {
-  default:
-  case DATADOG_PHP_LOG_UNKNOWN:
-    return "unknown";
-  case DATADOG_PHP_LOG_OFF:
-    return "off";
-  case DATADOG_PHP_LOG_ERROR:
-    return "error";
-  case DATADOG_PHP_LOG_WARN:
-    return "warn";
-  case DATADOG_PHP_LOG_INFO:
-    return "info";
-  case DATADOG_PHP_LOG_DEBUG:
-    return "debug";
-  }
-}
-
 static void datadog_info_print_esc_view(datadog_php_string_view str);
 static void datadog_info_print_esc(const char *str);
 static void datadog_info_print(const char *);

--- a/profiling/env/CMakeLists.txt
+++ b/profiling/env/CMakeLists.txt
@@ -1,19 +1,14 @@
 add_library(datadog-php-env OBJECT env.c env.h)
 
-target_include_directories(datadog-php-env
-  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
-)
+target_include_directories(
+  datadog-php-env INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
 
-target_compile_features(datadog-php-env
+target_compile_features(
+  datadog-php-env
   INTERFACE c_std_99
-  PRIVATE c_std_11
-)
+  PRIVATE c_std_11)
 
-target_link_libraries(datadog-php-env
-  PUBLIC
-    datadog-php-arena
-    datadog-php-log
-    datadog_php_string_view
-    DDProf::FFI
-  PRIVATE PhpConfig::PhpConfig
-)
+target_link_libraries(
+  datadog-php-env
+  PUBLIC datadog-php-arena datadog-php-log datadog_php_string_view DDProf::FFI
+  PRIVATE PhpConfig::PhpConfig)

--- a/profiling/stack-collector/CMakeLists.txt
+++ b/profiling/stack-collector/CMakeLists.txt
@@ -1,15 +1,16 @@
-add_library(datadog-php-stack-collector OBJECT stack-collector.c stack-collector.h)
+add_library(datadog-php-stack-collector OBJECT stack-collector.c
+                                               stack-collector.h)
 
-target_include_directories(datadog-php-stack-collector
-  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
-)
+target_include_directories(
+  datadog-php-stack-collector
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
 
-target_compile_features(datadog-php-stack-collector
+target_compile_features(
+  datadog-php-stack-collector
   INTERFACE c_std_99
-  PRIVATE c_std_11
-)
+  PRIVATE c_std_11)
 
-target_link_libraries(datadog-php-stack-collector
+target_link_libraries(
+  datadog-php-stack-collector
   PUBLIC datadog-php-stack-sample
-  PRIVATE datadog_php_string_view PhpConfig::PhpConfig
-)
+  PRIVATE datadog_php_string_view PhpConfig::PhpConfig)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(phpt)

--- a/tests/phpt/CMakeLists.txt
+++ b/tests/phpt/CMakeLists.txt
@@ -1,9 +1,19 @@
 file(GLOB_RECURSE RUN_TESTS_CANDIDATES ${PhpConfig_ROOT_DIR}/**/run-tests.php)
 list(POP_FRONT RUN_TESTS_CANDIDATES RUN_TESTS)
 
+#[[ The run-tests.php file may not be able to be run in-place because it does
+    some file I/O relative to its location, and the user may not have
+    permissions. So, copy it to the build dir.
+ ]]
+add_test(NAME datadog-php-copy-run-tests
+         COMMAND ${CMAKE_COMMAND} -E copy ${RUN_TESTS}
+                 ${CMAKE_CURRENT_BINARY_DIR}/run-tests.php)
+
 add_test(
   NAME datadog-php-phpt-tests
-  COMMAND ${PhpConfig_PHP_BINARY} ${RUN_TESTS} -p ${PhpConfig_PHP_BINARY} -d
-          zend_extension=$<TARGET_FILE:datadog-profiling> .
+  COMMAND
+    ${PhpConfig_PHP_BINARY} ${CMAKE_CURRENT_BINARY_DIR}/run-tests.php -p
+    ${PhpConfig_PHP_BINARY} -d zend_extension=$<TARGET_FILE:datadog-profiling> .
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-set_tests_properties(datadog-php-phpt-tests PROPERTIES LABELS phpt)
+set_tests_properties(datadog-php-phpt-tests
+                     PROPERTIES LABELS phpt DEPENDS datadog-php-copy-run-tests)

--- a/tests/phpt/CMakeLists.txt
+++ b/tests/phpt/CMakeLists.txt
@@ -3,7 +3,7 @@ list(POP_FRONT RUN_TESTS_CANDIDATES RUN_TESTS)
 
 add_test(
   NAME datadog-php-phpt-tests
-  COMMAND ${PhpConfig_PHP_BINARY} ${RUN_TESTS} -d
+  COMMAND ${PhpConfig_PHP_BINARY} ${RUN_TESTS} -p ${PhpConfig_PHP_BINARY} -d
           zend_extension=$<TARGET_FILE:datadog-profiling> .
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 set_tests_properties(datadog-php-phpt-tests PROPERTIES LABELS phpt)

--- a/tests/phpt/CMakeLists.txt
+++ b/tests/phpt/CMakeLists.txt
@@ -1,0 +1,9 @@
+file(GLOB_RECURSE RUN_TESTS_CANDIDATES ${PhpConfig_ROOT_DIR}/**/run-tests.php)
+list(POP_FRONT RUN_TESTS_CANDIDATES RUN_TESTS)
+
+add_test(
+  NAME datadog-php-phpt-tests
+  COMMAND ${PhpConfig_PHP_BINARY} ${RUN_TESTS} -d
+          zend_extension=$<TARGET_FILE:datadog-profiling> .
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+set_tests_properties(datadog-php-phpt-tests PROPERTIES LABELS phpt)

--- a/tests/phpt/phpinfo_01.phpt
+++ b/tests/phpt/phpinfo_01.phpt
@@ -1,0 +1,59 @@
+--TEST--
+[profiling] test profiler's extension info
+--DESCRIPTION--
+The profiler's phpinfo section contains important debugging information. This
+test verifies that certain information is present.
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+  echo "skip: test requires Datadog Continuous Profiler\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=no
+DD_PROFILING_LOG_LEVEL=info
+DD_PROFILING_EXPERIMENTAL_CPU_ENABLED=yes
+DD_SERVICE=datadog-profiling-phpt
+DD_ENV=dev
+DD_VERSION=13
+DD_AGENT_HOST=localh0st
+DD_TRACE_AGENT_PORT=80
+DD_TRACE_AGENT_URL=http://datadog:8126
+--INI--
+assert.exception=1
+--FILE--
+<?php
+
+ob_start();
+$extension = new ReflectionExtension('datadog-profiling');
+$extension->info();
+$output = ob_get_clean();
+
+$lines = preg_split("/\R/", $output);
+$values = [];
+foreach ($lines as $line) {
+    $pair = explode("=>", $line, 2);
+    if (count($pair) != 2) {
+        continue;
+    }
+    $values[trim($pair[0])] = trim($pair[1]);
+}
+
+$sections = [
+    ["Profiling Enabled", "false"],
+    ["Experimental CPU Profiling Enabled", "true"],
+    ["Profiling Log Level", "info"],
+    ["Profiling Agent Endpoint", "http://datadog:8126"],
+    ["Application's Environment (DD_ENV)", "dev"],
+    ["Application's Service (DD_SERVICE)", "datadog-profiling-phpt"],
+    ["Application's Version (DD_VERSION)", "13"],
+];
+
+foreach ($sections as list($key, $value)) {
+    assert($values[$key] == $value);
+}
+
+echo "Done.";
+
+?>
+--EXPECT--
+Done.


### PR DESCRIPTION
Also add another phpt test, and move some code out of the ext into
components for testing.

Also clean up profiling/env/env.c a bit using a struct rather than
implicit structure in code.

Also run cmake-format on CMakeLists.txt files.

Also fix a warning the queue tests.

These changes are in preparation for adding code coverage based on both
unit tests and phpt tests.