### PR TITLE
Add Code Hotspots

### DIFF
--- a/datadog-profiling.c
+++ b/datadog-profiling.c
@@ -25,6 +25,7 @@ ZEND_API zend_extension zend_extension_entry = {
     .activate = datadog_profiling_activate,
     .deactivate = datadog_profiling_deactivate,
     .shutdown = datadog_profiling_shutdown,
+    .message_handler = datadog_profiling_message_handler,
     .resource_number = -1,
 };
 

--- a/datadog-profiling.sym
+++ b/datadog-profiling.sym
@@ -3,6 +3,7 @@ global:
         zend_extension_entry;
         extension_version_info;
         datadog_profiling_interrupt_function;
+        datadog_profiling_runtime_id;
 
 local:
         *;

--- a/profiling/context.h
+++ b/profiling/context.h
@@ -1,0 +1,22 @@
+#ifndef DATADOG_PROFILING_CONTEXT_H
+#define DATADOG_PROFILING_CONTEXT_H
+
+#include <stdint.h>
+
+// Keep in sync with tracer's version (but they are different).
+
+struct ddtrace_profiling_context {
+  uint64_t local_root_span_id, span_id;
+};
+typedef struct ddtrace_profiling_context ddtrace_profiling_context;
+
+/**
+ * Provide the active trace information for the profiler.
+ * If there isn’t an active context, return 0 for both values.
+ * This needs to be safe to call even if tracing is disabled, but only needs
+ * to support being called from a PHP thread.
+ */
+extern ddtrace_profiling_context (*datadog_profiling_get_profiling_context)(
+    void);
+
+#endif // DATADOG_PROFILING_CONTEXT_H

--- a/profiling/php_datadog-profiling.h
+++ b/profiling/php_datadog-profiling.h
@@ -4,6 +4,8 @@
 #include <php_config.h>
 
 #include <Zend/zend_extensions.h>
+#include <Zend/zend_portability.h>
+#include <components/uuid/uuid.h>
 
 #define PHP_DATADOG_PROFILING_VERSION "0.4.0"
 
@@ -12,8 +14,12 @@ void datadog_profiling_activate(void);
 void datadog_profiling_deactivate(void);
 void datadog_profiling_shutdown(zend_extension *);
 void datadog_profiling_diagnostics(void);
+void datadog_profiling_message_handler(int message, void *arg);
 
+BEGIN_EXTERN_C()
 ZEND_API void datadog_profiling_interrupt_function(struct _zend_execute_data *);
+ZEND_API datadog_php_uuid datadog_profiling_runtime_id(void);
+END_EXTERN_C()
 
 #if defined(ZTS)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/profiling/plugins/recorder_plugin/recorder_plugin.h
+++ b/profiling/plugins/recorder_plugin/recorder_plugin.h
@@ -3,6 +3,7 @@
 
 #include <Zend/zend_extensions.h>
 #include <config/config.h>
+#include <profiling/context.h>
 #include <stack-collector/stack-collector.h>
 #include <stdatomic.h>
 #include <stdbool.h>
@@ -22,10 +23,9 @@ typedef struct datadog_php_record_values {
   int64_t cpu_time;  // cpu time in ns since last sample, may be 0
 } datadog_php_record_values;
 
-__attribute__((nonnull)) bool
-datadog_php_recorder_plugin_record(datadog_php_record_values record_values,
-                                   int64_t tid,
-                                   const datadog_php_stack_sample *sample);
+__attribute__((nonnull)) bool datadog_php_recorder_plugin_record(
+    datadog_php_record_values record_values, int64_t tid,
+    const datadog_php_stack_sample *sample, ddtrace_profiling_context context);
 
 void datadog_php_recorder_plugin_first_activate(
     const datadog_php_profiling_config *config);

--- a/profiling/plugins/stack_collector_plugin/stack_collector_plugin.c
+++ b/profiling/plugins/stack_collector_plugin/stack_collector_plugin.c
@@ -1,5 +1,6 @@
 #include "stack_collector_plugin.h"
 
+#include "../../context.h"
 #include "../log_plugin/log_plugin.h"
 #include "../recorder_plugin/recorder_plugin.h"
 #include <components/time/time.h>
@@ -350,8 +351,11 @@ static void datadog_php_stack_collector_interrupt_function(
       .cpu_time = cpu_time,
   };
 
+  struct ddtrace_profiling_context context =
+      datadog_profiling_get_profiling_context();
+
   datadog_php_recorder_plugin_record(values, zend_thread_id,
-                                     &thread_globals.sample);
+                                     &thread_globals.sample, context);
 }
 
 ZEND_API void


### PR DESCRIPTION
This adds support for Code Hotspots from the profiling side of things.
Corresponds to DataDog/dd-trace-php#1517.

This still needs tests.