### PR TITLE
Update to libddprof v0.4.0-rc.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ jobs:
           command: |
             set -euo pipefail
             user=$(whoami)
-            curl -OL https://github.com/DataDog/libddprof/releases/download/v0.3.0/libddprof-x86_64-unknown-linux-gnu.tar.gz
-            sha256sum="d9c64567e7ef5f957581dd81892b144b81e1f52fdf5671430c7af0b039b48929"
+            curl -OL https://github.com/DataDog/libddprof/releases/download/v0.4.0-rc.1/libddprof-x86_64-unknown-linux-gnu.tar.gz
+            sha256sum="6b18703b24b5408d7071bfe1ddeb5bf73454ad6669e31b37a8401ad94ca9aed6"
             echo "$sha256sum  libddprof-x86_64-unknown-linux-gnu.tar.gz" | sha256sum -c
             export DDProf_ROOT="/opt/libddprof"
             sudo mkdir -p "$DDProf_ROOT"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ variables:
   # These are gitlab variables so that it's easier to do a manual deploy
   # If these are set witih value and description, then it gives you UI elements
   DOWNSTREAM_BRANCH:
-    value: "main"
+    value: "libddprof-v0.4.0-rc.1"
     description: "Run a specific branch downstream"
 
 trigger_internal_build:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ variables:
   # These are gitlab variables so that it's easier to do a manual deploy
   # If these are set witih value and description, then it gives you UI elements
   DOWNSTREAM_BRANCH:
-    value: "libddprof-v0.4.0-rc.1"
+    value: "main"
     description: "Run a specific branch downstream"
 
 trigger_internal_build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,20 @@ endif()
 
 add_subdirectory(components)
 
+# Prefer static libddprof to shared
+set(_DATADOG_PHP_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES
+    ${CMAKE_FIND_LIBRARY_SUFFIXES})
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  set(CMAKE_FIND_LIBRARY_SUFFIXES .a .so)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  set(CMAKE_FIND_LIBRARY_SUFFIXES .a .dylib .so .tbd)
+endif()
+
 find_package(DDProf REQUIRED)
+
+# Restore
+set(CMAKE_FIND_LIBRARY_SUFFIXES
+    ${_DATADOG_PHP_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
 
 add_subdirectory(profiling)
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ you will need:
  - pkg-config
  - PHP 7.1+
  - libuv (todo: min version?) and its headers
- - libddprof v0.3 for your platform. This is a Rust library, so I recommend
+ - libddprof v0.4 for your platform. This is a Rust library, so I recommend
    using the pre-built artifacts available at
    [Datadog/libddprof](https://github.com/DataDog/libddprof/releases) so you
    don't need a Rust toolchain.


### PR DESCRIPTION
Requires a change to prefer static ddprof_ffi.

This shouldn't affect functionality -- just packaging and build systems
changes. In the future we could potentially run on aarch64.