### PR TITLE
Support another envvar for CPU time; fix memory leak

### DIFF
--- a/components/string_view/string_view.h
+++ b/components/string_view/string_view.h
@@ -29,7 +29,7 @@ typedef struct datadog_php_string_view {
  *   datadog_php_string_view str = DATADOG_PHP_STRING_VIEW_LITERAL("hello");
  */
 #define DATADOG_PHP_STRING_VIEW_LITERAL(cstr)                                  \
-  { sizeof(cstr) - 1, cstr }
+  { sizeof(cstr) - 1, cstr "" }
 
 /**
  * Converts the C string `cstr` into a string view by getting its length from

--- a/profiling/env/env.c
+++ b/profiling/env/env.c
@@ -141,7 +141,11 @@ datadog_php_profiling_getenvs(datadog_php_profiling_env *env,
         result = datadog_php_profiling_getenv(
             arena, sapi, "DD_PROFILING_EXPERIMENTAL_CPU_ENABLED");
         if (result.tag == DATADOG_PHP_PROFILING_GETENV_ERR) {
-          success = false;
+          if (result.err == DATADOG_PHP_PROFILING_GETENV_ERR_NOVAL) {
+            // fall back to empty string, consider it a success
+          } else if (result.err == DATADOG_PHP_PROFILING_GETENV_ERR_NOMEM) {
+            success = false;
+          }
           break;
         }
         cpu_enabled.ptr = result.ok.ptr;

--- a/profiling/env/env.c
+++ b/profiling/env/env.c
@@ -15,6 +15,67 @@ typedef char getenv_char;
 extern inline void
 datadog_php_profiling_env_default_ctor(datadog_php_profiling_env *env);
 
+typedef struct datadog_php_profiling_getenv_result_s {
+  enum {
+    DATADOG_PHP_PROFILING_GETENV_OK,
+    DATADOG_PHP_PROFILING_GETENV_ERR,
+  } tag;
+  union {
+    datadog_php_string_view ok;
+    enum {
+      DATADOG_PHP_PROFILING_GETENV_ERR_NOMEM,
+      DATADOG_PHP_PROFILING_GETENV_ERR_NOVAL,
+    } err;
+  };
+} datadog_php_profiling_getenv_result;
+
+/**
+ * This function fetches the SAPI's env var represented by `name`, falling back
+ * to the OS's env var if it's not found. The value is copied.
+ * Returns an error result if neither source defines the env var, or if the
+ * arena has insufficient capacity.
+ */
+static __attribute__((nonnull(1, 2, 3))) datadog_php_profiling_getenv_result
+datadog_php_profiling_getenv(datadog_php_arena *arena,
+                             const sapi_module_struct *sapi, const char *name) {
+  // try the SAPI first
+  char *val =
+      sapi->getenv ? sapi->getenv((getenv_char *)name, strlen(name)) : NULL;
+
+  datadog_php_profiling_getenv_result result;
+  bool needs_efree;
+  if (val == NULL) {
+    // fall back to the OS
+    val = getenv(name);
+
+    if (!val) {
+      result.tag = DATADOG_PHP_PROFILING_GETENV_ERR;
+      result.err = DATADOG_PHP_PROFILING_GETENV_ERR_NOVAL;
+      return result;
+    }
+    needs_efree = false;
+  } else {
+    needs_efree = true;
+  }
+
+  datadog_php_string_view view = datadog_php_string_view_from_cstr(val);
+
+  const char *bytes = datadog_php_arena_alloc_str(arena, view.len, view.ptr);
+
+  if (bytes) {
+    result.tag = DATADOG_PHP_PROFILING_GETENV_OK;
+    result.ok = (datadog_php_string_view){.ptr = bytes, .len = view.len};
+  } else {
+    result.tag = DATADOG_PHP_PROFILING_GETENV_ERR;
+    result.err = DATADOG_PHP_PROFILING_GETENV_ERR_NOMEM;
+  }
+
+  if (needs_efree) {
+    efree(val);
+  }
+  return result;
+}
+
 __attribute__((nonnull(1, 2, 3))) bool
 datadog_php_profiling_getenvs(datadog_php_profiling_env *env,
                               const sapi_module_struct *sapi,
@@ -27,8 +88,6 @@ datadog_php_profiling_getenvs(datadog_php_profiling_env *env,
       {"DD_AGENT_HOST", &env->agent_host},
       {"DD_ENV", &env->env},
       {"DD_PROFILING_ENABLED", &env->profiling_enabled},
-      {"DD_PROFILING_EXPERIMENTAL_CPU_ENABLED",
-       &env->profiling_experimental_cpu_enabled},
       {"DD_PROFILING_LOG_LEVEL", &env->profiling_log_level},
       {"DD_SERVICE", &env->service},
       {"DD_TAGS", &env->tags},
@@ -45,29 +104,61 @@ datadog_php_profiling_getenvs(datadog_php_profiling_env *env,
   size_t n = sizeof envs / sizeof envs[0];
   for (i = 0; i != n; ++i) {
     const char *name = envs[i].name;
+    datadog_php_profiling_getenv_result result =
+        datadog_php_profiling_getenv(arena, sapi, name);
 
-    // try the SAPI first
-    char *val =
-        sapi->getenv ? sapi->getenv((getenv_char *)name, strlen(name)) : NULL;
-
-    // fall back to the OS
-    if (!val) {
-      val = getenv(name);
+    if (result.tag == DATADOG_PHP_PROFILING_GETENV_ERR) {
+      if (result.err == DATADOG_PHP_PROFILING_GETENV_ERR_NOMEM) {
+        break;
+      } else if (result.err == DATADOG_PHP_PROFILING_GETENV_ERR_NOVAL) {
+        // Default to empty string if there isn't a value.
+        result.tag = DATADOG_PHP_PROFILING_GETENV_OK;
+        result.ok = datadog_php_string_view_from_cstr("");
+      }
     }
 
-    datadog_php_string_view view = datadog_php_string_view_from_cstr(val);
-    const char *bytes = datadog_php_arena_alloc_str(arena, view.len, view.ptr);
-    if (!bytes) {
-      break;
+    envs[i].value->ptr = result.ok.ptr;
+    envs[i].value->len = result.ok.len;
+  }
+
+  bool success = i == n;
+  if (success) {
+    /* There are two env vars for CPU time because I goofed :'(
+     * Prefer DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED, because that's what
+     * is in the documentation.
+     */
+    datadog_php_profiling_getenv_result result = datadog_php_profiling_getenv(
+        arena, sapi, "DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED");
+
+    ddprof_ffi_CharSlice cpu_enabled = {.ptr = "", .len = 0};
+    if (result.tag == DATADOG_PHP_PROFILING_GETENV_ERR) {
+      switch (result.err) {
+      case DATADOG_PHP_PROFILING_GETENV_ERR_NOMEM:
+        success = false;
+        break;
+      case DATADOG_PHP_PROFILING_GETENV_ERR_NOVAL:
+        // fall back to undocumented version that has been around longer.
+        result = datadog_php_profiling_getenv(
+            arena, sapi, "DD_PROFILING_EXPERIMENTAL_CPU_ENABLED");
+        if (result.tag == DATADOG_PHP_PROFILING_GETENV_ERR) {
+          success = false;
+          break;
+        }
+        cpu_enabled.ptr = result.ok.ptr;
+        cpu_enabled.len = result.ok.len;
+        break;
+      }
+    } else {
+      cpu_enabled.ptr = result.ok.ptr;
+      cpu_enabled.len = result.ok.len;
     }
 
-    envs[i].value->len = view.len;
-    envs[i].value->ptr = bytes;
+    env->profiling_experimental_cpu_enabled = cpu_enabled;
   }
 
 #if PHP_VERSION_ID >= 70400
   tsrm_env_unlock();
 #endif
 
-  return i == n;
+  return success;
 }


### PR DESCRIPTION
The profiler recognizes `DD_PROFILING_EXPERIMENTAL_CPU_ENABLED`, but
the feature is documented as
`DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED`. This adds support for the
latter and prefers it.

Also fixes a memory leak which occurs in env var handling. Given this
happens only once per process, the leak is not very significant.