### PR TITLE
Avoid .message_handler due to upstream bug

### DIFF
--- a/datadog-profiling.c
+++ b/datadog-profiling.c
@@ -26,7 +26,6 @@ ZEND_API zend_extension zend_extension_entry = {
     .activate = datadog_profiling_activate,
     .deactivate = datadog_profiling_deactivate,
     .shutdown = datadog_profiling_shutdown,
-    .message_handler = datadog_profiling_message_handler,
     .resource_number = -1,
 };
 

--- a/profiling/php_datadog-profiling.h
+++ b/profiling/php_datadog-profiling.h
@@ -18,7 +18,6 @@ void datadog_profiling_activate(void);
 void datadog_profiling_deactivate(void);
 void datadog_profiling_shutdown(zend_extension *);
 void datadog_profiling_diagnostics(void);
-void datadog_profiling_message_handler(int message, void *arg);
 
 BEGIN_EXTERN_C()
 ZEND_API void datadog_profiling_interrupt_function(struct _zend_execute_data *);


### PR DESCRIPTION
The engine's message_handler dispatch implementation has been broken
for decades if more than one extension uses it, which is surprising
because having more than one zend_extension is exactly why you would
use it. The function `zend_llist_apply_with_arguments` does not
`va_copy` its `va_args` array for each extension it dispatches to.

See also datadog/dd-trace-php#1670.